### PR TITLE
Add PnSeen plugin: /seen lookup with persistent player data and reload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.pn86</groupId>
+    <artifactId>pnseen</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>PnSeen</name>
+    <description>PnSeen plugin for Paper 1.21.1</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/pn86/pnseen/PnSeenPlugin.java
+++ b/src/main/java/com/pn86/pnseen/PnSeenPlugin.java
@@ -1,0 +1,123 @@
+package com.pn86.pnseen;
+
+import com.pn86.pnseen.command.ReloadCommand;
+import com.pn86.pnseen.command.SeenCommand;
+import com.pn86.pnseen.data.PlayerData;
+import com.pn86.pnseen.data.PlayerDataStore;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.net.InetSocketAddress;
+import java.util.UUID;
+
+public class PnSeenPlugin extends JavaPlugin implements Listener {
+    private PlayerDataStore dataStore;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        dataStore = new PlayerDataStore(this);
+        dataStore.load();
+        getServer().getPluginManager().registerEvents(this, this);
+
+        PluginCommand seenCommand = getCommand("seen");
+        if (seenCommand != null) {
+            seenCommand.setExecutor(new SeenCommand(this));
+        }
+        PluginCommand reloadCommand = getCommand("pnseen");
+        if (reloadCommand != null) {
+            reloadCommand.setExecutor(new ReloadCommand(this));
+        }
+
+        Bukkit.getScheduler().runTaskTimer(this, () -> {
+            long now = System.currentTimeMillis();
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                updatePlayerData(player, now, true);
+            }
+            dataStore.save();
+        }, 20L * 60, 20L * 60);
+    }
+
+    @Override
+    public void onDisable() {
+        long now = System.currentTimeMillis();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            updatePlayerData(player, now, false);
+        }
+        dataStore.save();
+    }
+
+    public PlayerDataStore getDataStore() {
+        return dataStore;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        PlayerData data = dataStore.getOrCreate(player.getUniqueId());
+        data.setName(player.getName());
+        data.setLastJoinMillis(System.currentTimeMillis());
+        updateLocationAndIp(player, data);
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        long now = System.currentTimeMillis();
+        PlayerData data = dataStore.getOrCreate(player.getUniqueId());
+        data.setName(player.getName());
+        if (data.getLastJoinMillis() > 0) {
+            data.setTotalPlaytimeMillis(data.getTotalPlaytimeMillis() + (now - data.getLastJoinMillis()));
+        }
+        data.setLastJoinMillis(0);
+        data.setLastSeenMillis(now);
+        updateLocationAndIp(player, data);
+        dataStore.save();
+    }
+
+    private void updatePlayerData(Player player, long now, boolean rollingUpdate) {
+        PlayerData data = dataStore.getOrCreate(player.getUniqueId());
+        data.setName(player.getName());
+        if (data.getLastJoinMillis() > 0) {
+            long delta = now - data.getLastJoinMillis();
+            data.setTotalPlaytimeMillis(data.getTotalPlaytimeMillis() + delta);
+            if (rollingUpdate) {
+                data.setLastJoinMillis(now);
+            }
+        } else if (rollingUpdate) {
+            data.setLastJoinMillis(now);
+        }
+        updateLocationAndIp(player, data);
+    }
+
+    private void updateLocationAndIp(Player player, PlayerData data) {
+        Location location = player.getLocation();
+        data.setLastWorld(location.getWorld() != null ? location.getWorld().getName() : null);
+        data.setLastX(location.getX());
+        data.setLastY(location.getY());
+        data.setLastZ(location.getZ());
+        InetSocketAddress address = player.getAddress();
+        if (address != null && address.getAddress() != null) {
+            data.setLastIp(address.getAddress().getHostAddress());
+        }
+    }
+
+    public String getMessage(String path) {
+        return getConfig().getString(path, "");
+    }
+
+    public String colorize(String message) {
+        return message.replace("&", "§");
+    }
+
+    public PlayerData getData(UUID uuid) {
+        return dataStore.get(uuid);
+    }
+}

--- a/src/main/java/com/pn86/pnseen/command/ReloadCommand.java
+++ b/src/main/java/com/pn86/pnseen/command/ReloadCommand.java
@@ -1,0 +1,32 @@
+package com.pn86.pnseen.command;
+
+import com.pn86.pnseen.PnSeenPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class ReloadCommand implements CommandExecutor {
+    private final PnSeenPlugin plugin;
+
+    public ReloadCommand(PnSeenPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("pnseen.use")) {
+            sender.sendMessage(plugin.colorize(plugin.getMessage("messages.prefix")
+                    + plugin.getMessage("messages.no-permission")));
+            return true;
+        }
+        if (args.length != 1 || !args[0].equalsIgnoreCase("reload")) {
+            sender.sendMessage(plugin.colorize(plugin.getMessage("messages.prefix")
+                    + plugin.getMessage("messages.usage-reload")));
+            return true;
+        }
+        plugin.reloadConfig();
+        sender.sendMessage(plugin.colorize(plugin.getMessage("messages.prefix")
+                + plugin.getMessage("messages.reload-success")));
+        return true;
+    }
+}

--- a/src/main/java/com/pn86/pnseen/command/SeenCommand.java
+++ b/src/main/java/com/pn86/pnseen/command/SeenCommand.java
@@ -1,0 +1,158 @@
+package com.pn86.pnseen.command;
+
+import com.pn86.pnseen.PnSeenPlugin;
+import com.pn86.pnseen.data.PlayerData;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public class SeenCommand implements CommandExecutor {
+    private final PnSeenPlugin plugin;
+
+    public SeenCommand(PnSeenPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("pnseen.use")) {
+            sender.sendMessage(plugin.colorize(plugin.getMessage("messages.prefix")
+                    + plugin.getMessage("messages.no-permission")));
+            return true;
+        }
+        if (args.length < 1) {
+            sender.sendMessage(plugin.colorize(plugin.getMessage("messages.prefix")
+                    + plugin.getMessage("messages.usage-seen")));
+            return true;
+        }
+
+        String target = args[0];
+        Player player = Bukkit.getPlayerExact(target);
+        PlayerData data = null;
+
+        if (player != null) {
+            data = plugin.getDataStore().getOrCreate(player.getUniqueId());
+        } else {
+            try {
+                UUID uuid = UUID.fromString(target);
+                data = plugin.getDataStore().get(uuid);
+                if (data == null) {
+                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(uuid);
+                    if (offlinePlayer.getName() != null) {
+                        data = plugin.getDataStore().getOrCreate(uuid);
+                        data.setName(offlinePlayer.getName());
+                    }
+                }
+            } catch (IllegalArgumentException ignored) {
+                data = plugin.getDataStore().findByName(target);
+                if (data == null) {
+                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(target);
+                    if (offlinePlayer != null && offlinePlayer.getUniqueId() != null) {
+                        data = plugin.getDataStore().get(offlinePlayer.getUniqueId());
+                    }
+                }
+            }
+        }
+
+        if (data == null || data.getName() == null) {
+            sender.sendMessage(plugin.colorize(plugin.getMessage("messages.prefix")
+                    + plugin.getMessage("messages.player-not-found")));
+            return true;
+        }
+
+        boolean isOnline = player != null;
+        long now = System.currentTimeMillis();
+        long totalPlaytime = data.getTotalPlaytimeMillis();
+        long sessionTime = 0;
+        if (isOnline && data.getLastJoinMillis() > 0) {
+            sessionTime = now - data.getLastJoinMillis();
+        }
+        String playtimeText = formatDuration(totalPlaytime + sessionTime);
+
+        String offlineText = "";
+        if (!isOnline) {
+            if (data.getLastSeenMillis() > 0) {
+                offlineText = formatDuration(now - data.getLastSeenMillis());
+            } else {
+                offlineText = "未知";
+            }
+        }
+
+        Location location = null;
+        String worldName = data.getLastWorld();
+        double x = data.getLastX();
+        double y = data.getLastY();
+        double z = data.getLastZ();
+
+        if (isOnline) {
+            location = player.getLocation();
+            worldName = location.getWorld() != null ? location.getWorld().getName() : worldName;
+            x = location.getX();
+            y = location.getY();
+            z = location.getZ();
+        }
+
+        sendInfo(sender, data, isOnline, playtimeText, offlineText, worldName, x, y, z);
+        return true;
+    }
+
+    private void sendInfo(CommandSender sender, PlayerData data, boolean isOnline,
+                          String playtimeText, String offlineText,
+                          String worldName, double x, double y, double z) {
+        sender.sendMessage(plugin.colorize(replace(plugin.getMessage("messages.info.name"), data)));
+        sender.sendMessage(plugin.colorize(replace(plugin.getMessage("messages.info.uuid"), data)));
+        sender.sendMessage(plugin.colorize(plugin.getMessage("messages.info.playtime")
+                .replace("%playtime%", playtimeText)));
+
+        if (isOnline) {
+            sender.sendMessage(plugin.colorize(plugin.getMessage("messages.info.online")
+                    .replace("%online%", playtimeText)));
+        } else {
+            sender.sendMessage(plugin.colorize(plugin.getMessage("messages.info.offline")
+                    .replace("%offline%", offlineText)
+                    .replace("%online%", playtimeText)));
+        }
+
+        sender.sendMessage(plugin.colorize(plugin.getMessage("messages.info.location")
+                .replace("%x%", formatLocation(x))
+                .replace("%y%", formatLocation(y))
+                .replace("%z%", formatLocation(z))
+                .replace("%world%", worldName != null ? worldName : "未知")));
+
+        String ip = data.getLastIp() != null ? data.getLastIp() : "未知";
+        sender.sendMessage(plugin.colorize(plugin.getMessage("messages.info.ip")
+                .replace("%ip%", ip)));
+    }
+
+    private String replace(String message, PlayerData data) {
+        return message.replace("%name%", data.getName() != null ? data.getName() : "未知")
+                .replace("%uuid%", data.getUuid().toString());
+    }
+
+    private String formatLocation(double value) {
+        return String.format("%.2f", value);
+    }
+
+    private String formatDuration(long millis) {
+        long minutes = millis / 60000;
+        long hours = minutes / 60;
+        long days = hours / 24;
+
+        if (days > 0) {
+            long remainingHours = hours % 24;
+            long remainingMinutes = minutes % 60;
+            return days + "天" + remainingHours + "小时" + remainingMinutes + "分钟";
+        }
+        if (hours > 0) {
+            long remainingMinutes = minutes % 60;
+            return hours + "小时" + remainingMinutes + "分钟";
+        }
+        return minutes + "分钟";
+    }
+}

--- a/src/main/java/com/pn86/pnseen/data/PlayerData.java
+++ b/src/main/java/com/pn86/pnseen/data/PlayerData.java
@@ -1,0 +1,96 @@
+package com.pn86.pnseen.data;
+
+import java.util.UUID;
+
+public class PlayerData {
+    private final UUID uuid;
+    private String name;
+    private long totalPlaytimeMillis;
+    private long lastJoinMillis;
+    private long lastSeenMillis;
+    private String lastWorld;
+    private double lastX;
+    private double lastY;
+    private double lastZ;
+    private String lastIp;
+
+    public PlayerData(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public long getTotalPlaytimeMillis() {
+        return totalPlaytimeMillis;
+    }
+
+    public void setTotalPlaytimeMillis(long totalPlaytimeMillis) {
+        this.totalPlaytimeMillis = totalPlaytimeMillis;
+    }
+
+    public long getLastJoinMillis() {
+        return lastJoinMillis;
+    }
+
+    public void setLastJoinMillis(long lastJoinMillis) {
+        this.lastJoinMillis = lastJoinMillis;
+    }
+
+    public long getLastSeenMillis() {
+        return lastSeenMillis;
+    }
+
+    public void setLastSeenMillis(long lastSeenMillis) {
+        this.lastSeenMillis = lastSeenMillis;
+    }
+
+    public String getLastWorld() {
+        return lastWorld;
+    }
+
+    public void setLastWorld(String lastWorld) {
+        this.lastWorld = lastWorld;
+    }
+
+    public double getLastX() {
+        return lastX;
+    }
+
+    public void setLastX(double lastX) {
+        this.lastX = lastX;
+    }
+
+    public double getLastY() {
+        return lastY;
+    }
+
+    public void setLastY(double lastY) {
+        this.lastY = lastY;
+    }
+
+    public double getLastZ() {
+        return lastZ;
+    }
+
+    public void setLastZ(double lastZ) {
+        this.lastZ = lastZ;
+    }
+
+    public String getLastIp() {
+        return lastIp;
+    }
+
+    public void setLastIp(String lastIp) {
+        this.lastIp = lastIp;
+    }
+}

--- a/src/main/java/com/pn86/pnseen/data/PlayerDataStore.java
+++ b/src/main/java/com/pn86/pnseen/data/PlayerDataStore.java
@@ -1,0 +1,104 @@
+package com.pn86.pnseen.data;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+public class PlayerDataStore {
+    private final JavaPlugin plugin;
+    private final File dataFile;
+    private final Map<UUID, PlayerData> dataMap = new HashMap<>();
+
+    public PlayerDataStore(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.dataFile = new File(plugin.getDataFolder(), "data.yml");
+    }
+
+    public PlayerData getOrCreate(UUID uuid) {
+        return dataMap.computeIfAbsent(uuid, PlayerData::new);
+    }
+
+    public PlayerData get(UUID uuid) {
+        return dataMap.get(uuid);
+    }
+
+    public PlayerData findByName(String name) {
+        String lower = name.toLowerCase(Locale.ROOT);
+        for (PlayerData data : dataMap.values()) {
+            if (data.getName() != null && data.getName().toLowerCase(Locale.ROOT).equals(lower)) {
+                return data;
+            }
+        }
+        return null;
+    }
+
+    public Collection<PlayerData> getAll() {
+        return Collections.unmodifiableCollection(dataMap.values());
+    }
+
+    public void load() {
+        dataMap.clear();
+        if (!dataFile.exists()) {
+            return;
+        }
+        FileConfiguration config = YamlConfiguration.loadConfiguration(dataFile);
+        ConfigurationSection root = config.getConfigurationSection("players");
+        if (root == null) {
+            return;
+        }
+        for (String key : root.getKeys(false)) {
+            try {
+                UUID uuid = UUID.fromString(key);
+                ConfigurationSection section = root.getConfigurationSection(key);
+                if (section == null) {
+                    continue;
+                }
+                PlayerData data = new PlayerData(uuid);
+                data.setName(section.getString("name"));
+                data.setTotalPlaytimeMillis(section.getLong("totalPlaytimeMillis"));
+                data.setLastJoinMillis(section.getLong("lastJoinMillis"));
+                data.setLastSeenMillis(section.getLong("lastSeenMillis"));
+                data.setLastWorld(section.getString("lastWorld"));
+                data.setLastX(section.getDouble("lastX"));
+                data.setLastY(section.getDouble("lastY"));
+                data.setLastZ(section.getDouble("lastZ"));
+                data.setLastIp(section.getString("lastIp"));
+                dataMap.put(uuid, data);
+            } catch (IllegalArgumentException ignored) {
+                plugin.getLogger().warning("无法解析玩家UUID: " + key);
+            }
+        }
+    }
+
+    public void save() {
+        FileConfiguration config = new YamlConfiguration();
+        ConfigurationSection root = config.createSection("players");
+        for (PlayerData data : dataMap.values()) {
+            ConfigurationSection section = root.createSection(data.getUuid().toString());
+            section.set("name", data.getName());
+            section.set("totalPlaytimeMillis", data.getTotalPlaytimeMillis());
+            section.set("lastJoinMillis", data.getLastJoinMillis());
+            section.set("lastSeenMillis", data.getLastSeenMillis());
+            section.set("lastWorld", data.getLastWorld());
+            section.set("lastX", data.getLastX());
+            section.set("lastY", data.getLastY());
+            section.set("lastZ", data.getLastZ());
+            section.set("lastIp", data.getLastIp());
+        }
+        try {
+            config.save(dataFile);
+        } catch (IOException e) {
+            plugin.getLogger().warning("无法保存 data.yml: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,15 @@
+messages:
+  prefix: "&7[&aPnSeen&7] "
+  no-permission: "&c你没有权限使用此命令。"
+  reload-success: "&a配置文件已重载。"
+  usage-seen: "&c用法: /seen <玩家名|UUID>"
+  usage-reload: "&c用法: /pnseen reload"
+  player-not-found: "&c未找到该玩家。"
+  info:
+    name: "&f玩家名：&a%name%"
+    uuid: "&f玩家UUID：&a%uuid%"
+    playtime: "&f玩家累计在线时间：&a%playtime%"
+    offline: "&f玩家离线了 &a%offline%&f（玩家上线了 &a%online%&f）"
+    online: "&f玩家上线了 &a%online%"
+    location: "&f玩家位置: &a%x% %y% %z% (%world%)"
+    ip: "&f玩家IP: &a%ip%"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,18 @@
+name: PnSeen
+main: com.pn86.pnseen.PnSeenPlugin
+version: 1.0.0
+api-version: '1.21'
+author: Pn86
+commands:
+  seen:
+    description: 查看玩家信息
+    usage: /seen <玩家名|UUID>
+    permission: pnseen.use
+  pnseen:
+    description: PnSeen 管理命令
+    usage: /pnseen reload
+    permission: pnseen.use
+permissions:
+  pnseen.use:
+    description: 允许使用 /seen 与 /pnseen reload
+    default: op


### PR DESCRIPTION
### Motivation
- Provide a Paper 1.21.1 plugin that allows server operators to query player information with `/seen`.
- Persist realtime player info (name, UUID, total playtime, last seen, location, IP) so lookups work after server restarts.
- Restrict both query and reload to the `pnseen.use` permission and expose a `pnseen reload` management command.

### Description
- Add `PnSeenPlugin` as the plugin entrypoint with event listeners for `PlayerJoinEvent`/`PlayerQuitEvent` and a scheduled task that updates and saves player data periodically.
- Implement `PlayerData` and `PlayerDataStore` to hold player fields and load/save them to `data.yml` via Bukkit `YamlConfiguration`.
- Add `SeenCommand` and `ReloadCommand` to perform permission-checked lookups and configuration reloads, with formatted messages and playtime/location formatting.
- Add resource files `config.yml` (Chinese message templates), `plugin.yml` (commands and `pnseen.use` permission), and `pom.xml` (Maven project targeting Paper `1.21.1-R0.1-SNAPSHOT` and Java 17).

### Testing
- No automated tests were executed for this change; recommend running `mvn package` and installing the resulting JAR on a Paper 1.21.1 server for runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f37398f48332b1eb10c9eaed26c3)