### PR TITLE
Add PnPlunderV Paper 1.21.1 plugin for PvP Vault plunder

### DIFF
--- a/PnPlunderV/pom.xml
+++ b/PnPlunderV/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>cn.pn86</groupId>
+    <artifactId>PnPlunderV</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>PnPlunderV</name>
+    <description>PVP plunder plugin for Paper 1.21.1</description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/PnPlunderV/src/main/java/cn/pn86/pnplunderv/PnPlunderVPlugin.java
+++ b/PnPlunderV/src/main/java/cn/pn86/pnplunderv/PnPlunderVPlugin.java
@@ -1,0 +1,56 @@
+package cn.pn86.pnplunderv;
+
+import cn.pn86.pnplunderv.command.PnPlunderCommand;
+import cn.pn86.pnplunderv.listener.PvpPlunderListener;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.RegisteredServiceProvider;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class PnPlunderVPlugin extends JavaPlugin {
+
+    private Economy economy;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+
+        if (!setupEconomy()) {
+            getLogger().severe("Vault economy provider not found, plugin disabled.");
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        PluginCommand command = getCommand("pnpv");
+        if (command == null) {
+            getLogger().severe("Command pnpv is missing in plugin.yml, plugin disabled.");
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        command.setExecutor(new PnPlunderCommand(this));
+        Bukkit.getPluginManager().registerEvents(new PvpPlunderListener(this), this);
+        getLogger().info("PnPlunderV enabled.");
+    }
+
+    public Economy getEconomy() {
+        return economy;
+    }
+
+    public void reloadPluginConfig() {
+        reloadConfig();
+    }
+
+    private boolean setupEconomy() {
+        if (Bukkit.getPluginManager().getPlugin("Vault") == null) {
+            return false;
+        }
+        RegisteredServiceProvider<Economy> rsp = Bukkit.getServicesManager().getRegistration(Economy.class);
+        if (rsp == null) {
+            return false;
+        }
+        economy = rsp.getProvider();
+        return economy != null;
+    }
+}

--- a/PnPlunderV/src/main/java/cn/pn86/pnplunderv/command/PnPlunderCommand.java
+++ b/PnPlunderV/src/main/java/cn/pn86/pnplunderv/command/PnPlunderCommand.java
@@ -1,0 +1,37 @@
+package cn.pn86.pnplunderv.command;
+
+import cn.pn86.pnplunderv.PnPlunderVPlugin;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class PnPlunderCommand implements CommandExecutor {
+
+    private final PnPlunderVPlugin plugin;
+
+    public PnPlunderCommand(PnPlunderVPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("pnpv.admin")) {
+            sender.sendMessage(color(plugin.getConfig().getString("messages.no-permission", "&c你没有权限执行此命令")));
+            return true;
+        }
+
+        if (args.length == 1 && args[0].equalsIgnoreCase("reload")) {
+            plugin.reloadPluginConfig();
+            sender.sendMessage(color(plugin.getConfig().getString("messages.reload-success", "&aPnPlunderV 配置重载完成")));
+            return true;
+        }
+
+        sender.sendMessage(color(plugin.getConfig().getString("messages.usage", "&e用法: /pnpv reload")));
+        return true;
+    }
+
+    private String color(String text) {
+        return ChatColor.translateAlternateColorCodes('&', text);
+    }
+}

--- a/PnPlunderV/src/main/java/cn/pn86/pnplunderv/listener/PvpPlunderListener.java
+++ b/PnPlunderV/src/main/java/cn/pn86/pnplunderv/listener/PvpPlunderListener.java
@@ -1,0 +1,73 @@
+package cn.pn86.pnplunderv.listener;
+
+import cn.pn86.pnplunderv.PnPlunderVPlugin;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+
+import java.text.DecimalFormat;
+
+public class PvpPlunderListener implements Listener {
+
+    private static final DecimalFormat MONEY_FORMAT = new DecimalFormat("0.##");
+
+    private final PnPlunderVPlugin plugin;
+
+    public PvpPlunderListener(PnPlunderVPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player victim = event.getEntity();
+        Player killer = victim.getKiller();
+        if (killer == null) {
+            return;
+        }
+
+        Economy economy = plugin.getEconomy();
+        if (economy == null) {
+            return;
+        }
+
+        double percent = plugin.getConfig().getDouble("plunder.percent", 10.0D);
+        if (percent <= 0) {
+            return;
+        }
+
+        double victimBalance = economy.getBalance(victim);
+        if (victimBalance <= 0) {
+            return;
+        }
+
+        double amount = victimBalance * (percent / 100D);
+        if (amount <= 0) {
+            return;
+        }
+
+        economy.withdrawPlayer(victim, amount);
+        economy.depositPlayer(killer, amount);
+
+        String subtitleTemplate = plugin.getConfig().getString(
+                "subtitle.content",
+                "&6{killer} &f击杀了 &c{victim}&f，掠夺金币: &e{amount}"
+        );
+        String subtitle = subtitleTemplate
+                .replace("{killer}", killer.getName())
+                .replace("{victim}", victim.getName())
+                .replace("{amount}", MONEY_FORMAT.format(amount));
+
+        int fadeIn = plugin.getConfig().getInt("subtitle.fade-in", 10);
+        int stay = plugin.getConfig().getInt("subtitle.stay", 50);
+        int fadeOut = plugin.getConfig().getInt("subtitle.fade-out", 10);
+
+        String coloredSubtitle = ChatColor.translateAlternateColorCodes('&', subtitle);
+        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+            onlinePlayer.sendTitle("", coloredSubtitle, fadeIn, stay, fadeOut);
+        }
+    }
+}

--- a/PnPlunderV/src/main/resources/config.yml
+++ b/PnPlunderV/src/main/resources/config.yml
@@ -1,0 +1,16 @@
+# 掠夺百分比（单位：%）
+plunder:
+  percent: 10.0
+
+# 全服 subtitle 播报设置（仅 subtitle）
+subtitle:
+  content: "&6{killer} &f击杀了 &c{victim}&f，掠夺金币: &e{amount}"
+  fade-in: 10
+  stay: 50
+  fade-out: 10
+
+# 语言信息
+messages:
+  no-permission: "&c你没有权限执行此命令"
+  reload-success: "&aPnPlunderV 配置重载完成"
+  usage: "&e用法: /pnpv reload"

--- a/PnPlunderV/src/main/resources/plugin.yml
+++ b/PnPlunderV/src/main/resources/plugin.yml
@@ -1,0 +1,17 @@
+name: PnPlunderV
+version: 1.0.0
+main: cn.pn86.pnplunderv.PnPlunderVPlugin
+api-version: '1.21'
+author: Pn86
+depend: [Vault]
+
+commands:
+  pnpv:
+    description: PnPlunderV 主命令
+    usage: /pnpv reload
+    permission: pnpv.admin
+
+permissions:
+  pnpv.admin:
+    description: PnPlunderV 管理权限
+    default: op


### PR DESCRIPTION
### Motivation
- Provide a very small Paper 1.21.1 plugin that enables PvP plunder using a Vault-backed economy with configurable percentage and server-wide subtitle notifications. 
- Allow server administrators to change messages and plunder settings via a single `config.yml` and to reload configuration with a command.

### Description
- Added a new module `PnPlunderV` with `pom.xml` declaring `paper-api` and `VaultAPI` as `provided` dependencies and Java 21 compiler settings. 
- Implemented `PnPlunderVPlugin` which loads default config, sets up Vault economy provider, registers the `/pnpv` command and the PvP listener, and disables the plugin if Vault is not present. 
- Implemented `PnPlunderCommand` to provide `/pnpv reload` with permission `pnpv.admin` and localized messages read from `config.yml`. 
- Implemented `PvpPlunderListener` to transfer a configurable percentage (`plunder.percent`) of the victim's Vault balance to the killer on PvP kills and broadcast a formatted, colorized subtitle to all online players using `subtitle.content` and timing settings. 
- Added `plugin.yml` and `config.yml` resources containing plugin metadata, permissions, the default plunder percent, subtitle template/timings, and language messages. 

### Testing
- Attempted to build the module with `mvn -f PnPlunderV/pom.xml package`, which failed due to Maven Central returning HTTP 403 while resolving `maven-resources-plugin`, preventing a successful package in this environment. 
- No automated unit tests are present for this module; behavior was implemented according to the Paper and Vault APIs and validated by static inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0758224e083328e6dff65f812a929)