### PR TITLE
Add PnMoney Bukkit plugin: currency, shop, storage and API (initial implementation)

### DIFF
--- a/PnMoney/README.md
+++ b/PnMoney/README.md
@@ -1,0 +1,91 @@
+# PnMoney (兼容 1.8.8 ~ 1.21.11)
+
+PnMoney 是一个带有基础货币系统与简单商店系统的插件。
+
+## 兼容性与旧数据
+- 插件代码已按 Java 8 与 Bukkit/Spigot 通用 API 编写，可用于 `1.8.8 ~ 1.21.11`。
+- **不改变**存储结构与配置格式：
+  - 仍使用 `config.yml`、`shop.yml`
+  - 数据表仍为 `pnmoney_balances`
+  - 默认 SQLite 文件仍为 `pnmoney.db`
+- 旧版本插件产生的数据可直接继续使用。
+
+## 指令
+- `/pnmy reload` 重载插件
+- `/pnmy give [玩家] [数量]` 给予玩家货币
+- `/pnmy take [玩家] [数量]` 拿去玩家货币
+- `/pnmy reset [玩家]` 重置玩家货币
+- `/pnmy set [玩家] [数量]` 设置玩家货币
+- `/pnmy pay [玩家] [数量]` 将自己的货币给予其他玩家
+- `/pnmy list [玩家]` 查看玩家货币
+- `/pnmy top` 查看货币排行榜
+- `/pnmy shop [商品ID]` 购买物品
+
+## 权限
+- `pnmoney.admin`：管理权限（reload/give/take/reset/set/pay/list他人）
+- `pnmoney.player`：普通玩家权限（shop/top/list自己）
+- `pnmoney.use`：兼容旧权限节点（与 `pnmoney.player` 等效用于普通功能）
+
+## 配置文件
+- `config.yml`
+  - 货币名称
+  - 允许负数
+  - 小数最大位数
+  - 货币最大值
+  - 默认货币值
+  - 语言信息
+  - 存储方式（SQLite / MySQL）
+- `shop.yml`
+  - `use`：是否启用商店
+  - 商品节点示例（正确格式）：
+    ```yml
+    use: true
+
+    "1":
+      int: "10"
+      item:
+        - "eco give %player% 100"
+
+    "vip_day":
+      int: "88.50"
+      item:
+        - "lp user %player% parent addtemp vip 1d"
+        - "tellraw %player% {\"text\":\"你成功购买了1天VIP！\",\"color\":\"gold\"}"
+    ```
+
+## 存储与迁移
+- 默认使用 SQLite（`plugins/PnMoney/pnmoney.db`）。
+- 当 `storage.type: mysql` 时，插件会连接 MySQL（MariaDB 驱动），并尝试把 SQLite 的 `pnmoney_balances` 自动迁移到 MySQL。
+- 余额操作为实时写入数据库，重启后可继续读取。
+
+## PlaceholderAPI
+- `%pnmoney.money%` 货币名称
+- `%pnmoney.bal%` 玩家余额
+
+## Shop 购买校验说明
+- 商店购买时会优先通过 PlaceholderAPI 解析 `%pnmoney.bal%` 来确认玩家余额。
+- 若服务器未安装 PlaceholderAPI，则自动回退为插件内部余额读取。
+- 仅当余额充足且扣款成功时才会执行 `shop.yml` 中的商品命令。
+
+## 对外 API
+插件主类提供 `getMoneyService()`，返回 `MoneyService` 接口。
+
+### API 接口
+```java
+import org.bukkit.Bukkit;
+import uno.mcme.pnmoney.PnMoneyPlugin;
+import uno.mcme.pnmoney.api.MoneyService;
+
+PnMoneyPlugin plugin = (PnMoneyPlugin) Bukkit.getPluginManager().getPlugin("PnMoney");
+if (plugin != null) {
+    MoneyService api = plugin.getMoneyService();
+    // api.getBalance(player)
+    // api.addBalance(player, new BigDecimal("100"))
+}
+```
+
+`MoneyService` 方法：
+- `BigDecimal getBalance(OfflinePlayer player)`
+- `boolean setBalance(OfflinePlayer player, BigDecimal amount)`
+- `boolean addBalance(OfflinePlayer player, BigDecimal amount)`
+- `boolean takeBalance(OfflinePlayer player, BigDecimal amount)`

--- a/PnMoney/pom.xml
+++ b/PnMoney/pom.xml
@@ -1,0 +1,85 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>uno.mcme</groupId>
+    <artifactId>PnMoney</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>PnMoney</name>
+    <description>Simple currency and shop plugin for Bukkit/Spigot 1.8.8+</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.6</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.46.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.4.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/MoneyManager.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/MoneyManager.java
@@ -1,0 +1,112 @@
+package uno.mcme.pnmoney;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.file.FileConfiguration;
+import uno.mcme.pnmoney.data.DatabaseManager;
+import uno.mcme.pnmoney.data.PlayerBalance;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.UUID;
+
+public class MoneyManager {
+
+    private final PnMoneyPlugin plugin;
+    private final DatabaseManager databaseManager;
+
+    public MoneyManager(PnMoneyPlugin plugin, DatabaseManager databaseManager) {
+        this.plugin = plugin;
+        this.databaseManager = databaseManager;
+    }
+
+    public String getCurrencyName() {
+        return plugin.getConfig().getString("currency.name", "金币");
+    }
+
+    public BigDecimal getDefaultBalance() {
+        return normalize(BigDecimal.valueOf(plugin.getConfig().getDouble("money.default", 0.0)));
+    }
+
+    public BigDecimal getMaxBalance() {
+        return normalize(BigDecimal.valueOf(plugin.getConfig().getDouble("money.max", 999999999.0)));
+    }
+
+    public boolean allowNegative() {
+        return plugin.getConfig().getBoolean("money.allow-negative", false);
+    }
+
+    public int getScale() {
+        return plugin.getConfig().getInt("money.max-decimal", 2);
+    }
+
+    public BigDecimal normalize(BigDecimal value) {
+        return value.setScale(getScale(), RoundingMode.DOWN);
+    }
+
+    public BigDecimal clamp(BigDecimal value) {
+        BigDecimal normalized = normalize(value);
+        if (!allowNegative() && normalized.compareTo(BigDecimal.ZERO) < 0) {
+            normalized = BigDecimal.ZERO;
+        }
+        if (normalized.compareTo(getMaxBalance()) > 0) {
+            normalized = getMaxBalance();
+        }
+        return normalized;
+    }
+
+    public BigDecimal getBalance(OfflinePlayer player) {
+        return databaseManager.getOrCreate(player.getUniqueId(), player.getName(), getDefaultBalance(), getScale());
+    }
+
+    public boolean setBalance(OfflinePlayer player, BigDecimal amount) {
+        BigDecimal target = clamp(amount);
+        return databaseManager.setBalance(player.getUniqueId(), player.getName(), target, getScale());
+    }
+
+    public boolean addBalance(OfflinePlayer player, BigDecimal amount) {
+        BigDecimal now = getBalance(player);
+        return setBalance(player, now.add(amount));
+    }
+
+    public boolean takeBalance(OfflinePlayer player, BigDecimal amount) {
+        BigDecimal now = getBalance(player);
+        BigDecimal target = now.subtract(amount);
+        if (!allowNegative() && target.compareTo(BigDecimal.ZERO) < 0) {
+            return false;
+        }
+        return setBalance(player, target);
+    }
+
+    public boolean hasEnough(OfflinePlayer player, BigDecimal amount) {
+        BigDecimal normalized = normalize(amount);
+        if (normalized.compareTo(BigDecimal.ZERO) <= 0) {
+            return false;
+        }
+        return getBalance(player).compareTo(normalized) >= 0;
+    }
+
+    public boolean resetBalance(OfflinePlayer player) {
+        return setBalance(player, getDefaultBalance());
+    }
+
+    public boolean transfer(OfflinePlayer from, OfflinePlayer to, BigDecimal amount) {
+        BigDecimal normalized = normalize(amount);
+        if (normalized.compareTo(BigDecimal.ZERO) <= 0) {
+            return false;
+        }
+
+        UUID fromId = from.getUniqueId();
+        UUID toId = to.getUniqueId();
+        return databaseManager.transfer(fromId, from.getName(), toId, to.getName(), normalized,
+                getDefaultBalance(), allowNegative(), getMaxBalance(), getScale());
+    }
+
+    public List<PlayerBalance> getTop(int limit) {
+        return databaseManager.getTop(limit);
+    }
+
+    public FileConfiguration getMessages() {
+        return plugin.getConfig();
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/PnMoneyPlaceholder.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/PnMoneyPlaceholder.java
@@ -1,0 +1,51 @@
+package uno.mcme.pnmoney;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PnMoneyPlaceholder extends PlaceholderExpansion {
+
+    private final PnMoneyPlugin plugin;
+    private final MoneyManager moneyManager;
+
+    public PnMoneyPlaceholder(PnMoneyPlugin plugin, MoneyManager moneyManager) {
+        this.plugin = plugin;
+        this.moneyManager = moneyManager;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "pnmoney";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "Pn86";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
+        if ("money".equalsIgnoreCase(params)) {
+            return moneyManager.getCurrencyName();
+        }
+        if ("bal".equalsIgnoreCase(params)) {
+            if (player == null) {
+                return "0";
+            }
+            return moneyManager.getBalance(player).stripTrailingZeros().toPlainString();
+        }
+        return null;
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/PnMoneyPlugin.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/PnMoneyPlugin.java
@@ -1,0 +1,60 @@
+package uno.mcme.pnmoney;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.java.JavaPlugin;
+import uno.mcme.pnmoney.api.MoneyService;
+import uno.mcme.pnmoney.api.MoneyServiceImpl;
+import uno.mcme.pnmoney.command.PnMoneyCommand;
+import uno.mcme.pnmoney.data.DatabaseManager;
+import uno.mcme.pnmoney.shop.ShopManager;
+
+public class PnMoneyPlugin extends JavaPlugin {
+
+    private DatabaseManager databaseManager;
+    private MoneyManager moneyManager;
+    private ShopManager shopManager;
+    private MoneyService moneyService;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        saveResource("shop.yml", false);
+
+        databaseManager = new DatabaseManager(this);
+        databaseManager.start();
+
+        moneyManager = new MoneyManager(this, databaseManager);
+        shopManager = new ShopManager(this, moneyManager);
+        moneyService = new MoneyServiceImpl(moneyManager);
+
+        PnMoneyCommand command = new PnMoneyCommand(this, moneyManager, shopManager);
+        PluginCommand pnmy = getCommand("pnmy");
+        if (pnmy != null) {
+            pnmy.setExecutor(command);
+            pnmy.setTabCompleter(command);
+        }
+
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            new PnMoneyPlaceholder(this, moneyManager).register();
+            getLogger().info("PlaceholderAPI detected, placeholders registered.");
+        }
+    }
+
+    @Override
+    public void onDisable() {
+        if (databaseManager != null) {
+            databaseManager.close();
+        }
+    }
+
+    public void reloadEverything() {
+        reloadConfig();
+        shopManager.reload();
+        databaseManager.reload();
+    }
+
+    public MoneyService getMoneyService() {
+        return moneyService;
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/api/MoneyService.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/api/MoneyService.java
@@ -1,0 +1,16 @@
+package uno.mcme.pnmoney.api;
+
+import org.bukkit.OfflinePlayer;
+
+import java.math.BigDecimal;
+
+public interface MoneyService {
+
+    BigDecimal getBalance(OfflinePlayer player);
+
+    boolean setBalance(OfflinePlayer player, BigDecimal amount);
+
+    boolean addBalance(OfflinePlayer player, BigDecimal amount);
+
+    boolean takeBalance(OfflinePlayer player, BigDecimal amount);
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/api/MoneyServiceImpl.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/api/MoneyServiceImpl.java
@@ -1,0 +1,35 @@
+package uno.mcme.pnmoney.api;
+
+import org.bukkit.OfflinePlayer;
+import uno.mcme.pnmoney.MoneyManager;
+
+import java.math.BigDecimal;
+
+public class MoneyServiceImpl implements MoneyService {
+
+    private final MoneyManager moneyManager;
+
+    public MoneyServiceImpl(MoneyManager moneyManager) {
+        this.moneyManager = moneyManager;
+    }
+
+    @Override
+    public BigDecimal getBalance(OfflinePlayer player) {
+        return moneyManager.getBalance(player);
+    }
+
+    @Override
+    public boolean setBalance(OfflinePlayer player, BigDecimal amount) {
+        return moneyManager.setBalance(player, amount);
+    }
+
+    @Override
+    public boolean addBalance(OfflinePlayer player, BigDecimal amount) {
+        return moneyManager.addBalance(player, amount);
+    }
+
+    @Override
+    public boolean takeBalance(OfflinePlayer player, BigDecimal amount) {
+        return moneyManager.takeBalance(player, amount);
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/command/PnMoneyCommand.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/command/PnMoneyCommand.java
@@ -1,0 +1,327 @@
+package uno.mcme.pnmoney.command;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import uno.mcme.pnmoney.MoneyManager;
+import uno.mcme.pnmoney.PnMoneyPlugin;
+import uno.mcme.pnmoney.data.PlayerBalance;
+import uno.mcme.pnmoney.shop.ShopManager;
+import uno.mcme.pnmoney.shop.ShopPurchaseResult;
+import uno.mcme.pnmoney.shop.ShopPurchaseStatus;
+import uno.mcme.pnmoney.util.Text;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PnMoneyCommand implements CommandExecutor, TabCompleter {
+
+    private final PnMoneyPlugin plugin;
+    private final MoneyManager money;
+    private final ShopManager shop;
+
+    public PnMoneyCommand(PnMoneyPlugin plugin, MoneyManager money, ShopManager shop) {
+        this.plugin = plugin;
+        this.money = money;
+        this.shop = shop;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+                             @NotNull String label, @NotNull String[] args) {
+        if (args.length == 0) {
+            send(sender, "messages.help");
+            return true;
+        }
+
+        String sub = args[0].toLowerCase();
+        if ("reload".equals(sub)) {
+            if (!sender.hasPermission("pnmoney.admin")) {
+                send(sender, "messages.no-permission");
+                return true;
+            }
+            plugin.reloadEverything();
+            send(sender, "messages.reload");
+            return true;
+        }
+
+        if ("give".equals(sub) || "take".equals(sub) || "set".equals(sub)) {
+            if (!sender.hasPermission("pnmoney.admin")) {
+                send(sender, "messages.no-permission");
+                return true;
+            }
+            return handleAdminAmount(sender, sub, args);
+        }
+
+        if ("reset".equals(sub)) {
+            if (!sender.hasPermission("pnmoney.admin")) {
+                send(sender, "messages.no-permission");
+                return true;
+            }
+            return handleReset(sender, args);
+        }
+
+        if ("pay".equals(sub)) {
+            if (!sender.hasPermission("pnmoney.admin")) {
+                send(sender, "messages.no-permission");
+                return false;
+            }
+            return handlePay(sender, args);
+        }
+
+        if ("list".equals(sub)) {
+            if (!sender.hasPermission("pnmoney.player")
+                    && !sender.hasPermission("pnmoney.use")
+                    && !sender.hasPermission("pnmoney.admin")) {
+                send(sender, "messages.no-permission");
+                return false;
+            }
+            return handleList(sender, args);
+        }
+
+        if ("top".equals(sub)) {
+            if (!sender.hasPermission("pnmoney.player")
+                    && !sender.hasPermission("pnmoney.use")
+                    && !sender.hasPermission("pnmoney.admin")) {
+                send(sender, "messages.no-permission");
+                return false;
+            }
+            return handleTop(sender);
+        }
+
+        if ("shop".equals(sub)) {
+            if (!sender.hasPermission("pnmoney.player")
+                    && !sender.hasPermission("pnmoney.use")
+                    && !sender.hasPermission("pnmoney.admin")) {
+                send(sender, "messages.no-permission");
+                return false;
+            }
+            return handleShop(sender, args);
+        }
+
+        send(sender, "messages.help");
+        return true;
+    }
+
+    private boolean handleAdminAmount(CommandSender sender, String sub, String[] args) {
+        if (args.length < 3) {
+            send(sender, "messages.invalid-usage");
+            return false;
+        }
+        OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
+        BigDecimal amount = parseAmount(sender, args[2]);
+        if (amount == null) {
+            return false;
+        }
+
+        boolean success;
+        if ("give".equals(sub)) {
+            success = money.addBalance(target, amount);
+        } else if ("take".equals(sub)) {
+            success = money.takeBalance(target, amount);
+        } else {
+            success = money.setBalance(target, amount);
+        }
+
+        if (!success) {
+            send(sender, "messages.operation-failed");
+            return false;
+        }
+
+        String msg = plugin.getConfig().getString("messages.admin-success", "&a操作成功: %target% -> %bal% %money%");
+        msg = msg.replace("%target%", target.getName() == null ? target.getUniqueId().toString() : target.getName())
+                .replace("%bal%", money.getBalance(target).stripTrailingZeros().toPlainString())
+                .replace("%money%", money.getCurrencyName());
+        sender.sendMessage(Text.color(msg));
+        return true;
+    }
+
+    private boolean handleReset(CommandSender sender, String[] args) {
+        if (args.length < 2) {
+            send(sender, "messages.invalid-usage");
+            return false;
+        }
+        OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
+        if (money.resetBalance(target)) {
+            send(sender, "messages.reset-success");
+            return true;
+        }
+        send(sender, "messages.operation-failed");
+        return false;
+    }
+
+    private boolean handlePay(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player)) {
+            send(sender, "messages.player-only");
+            return false;
+        }
+        Player player = (Player) sender;
+        if (args.length < 3) {
+            send(sender, "messages.invalid-usage");
+            return false;
+        }
+
+        OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
+        if (target.getUniqueId().equals(player.getUniqueId())) {
+            send(sender, "messages.pay-self");
+            return false;
+        }
+
+        BigDecimal amount = parseAmount(sender, args[2]);
+        if (amount == null) {
+            return false;
+        }
+
+        boolean success = money.transfer(player, target, amount);
+        if (!success) {
+            send(sender, "messages.not-enough");
+            return false;
+        }
+
+        String senderMsg = plugin.getConfig().getString("messages.pay-success", "&a支付成功: %target% +%amount% %money%")
+                .replace("%target%", target.getName() == null ? "unknown" : target.getName())
+                .replace("%amount%", amount.stripTrailingZeros().toPlainString())
+                .replace("%money%", money.getCurrencyName());
+        player.sendMessage(Text.color(senderMsg));
+
+        Player onlineTarget = Bukkit.getPlayer(target.getUniqueId());
+        if (onlineTarget != null) {
+            String receiveMsg = plugin.getConfig().getString("messages.receive", "&a你收到了 %from% 的 %amount% %money%")
+                    .replace("%from%", player.getName())
+                    .replace("%amount%", amount.stripTrailingZeros().toPlainString())
+                    .replace("%money%", money.getCurrencyName());
+            onlineTarget.sendMessage(Text.color(receiveMsg));
+        }
+        return true;
+    }
+
+    private boolean handleList(CommandSender sender, String[] args) {
+        OfflinePlayer target;
+        boolean isAdmin = sender.hasPermission("pnmoney.admin");
+        if (args.length >= 2) {
+            if (!isAdmin) {
+                send(sender, "messages.no-permission");
+                return false;
+            }
+            target = Bukkit.getOfflinePlayer(args[1]);
+        } else if (sender instanceof Player) {
+            target = (Player) sender;
+        } else {
+            send(sender, "messages.invalid-usage");
+            return false;
+        }
+
+        String msg = plugin.getConfig().getString("messages.balance", "&e%target% 余额: %bal% %money%")
+                .replace("%target%", target.getName() == null ? "unknown" : target.getName())
+                .replace("%bal%", money.getBalance(target).stripTrailingZeros().toPlainString())
+                .replace("%money%", money.getCurrencyName());
+        sender.sendMessage(Text.color(msg));
+        return true;
+    }
+
+    private boolean handleTop(CommandSender sender) {
+        List<PlayerBalance> top = money.getTop(10);
+        sender.sendMessage(Text.color(plugin.getConfig().getString("messages.top-title", "&6货币排行榜")));
+        int i = 1;
+        for (PlayerBalance balance : top) {
+            String line = plugin.getConfig().getString("messages.top-line", "&e#%index% &f%player% &7- &a%bal% %money%")
+                    .replace("%index%", String.valueOf(i++))
+                    .replace("%player%", balance.getPlayerName())
+                    .replace("%bal%", balance.getBalance().stripTrailingZeros().toPlainString())
+                    .replace("%money%", money.getCurrencyName());
+            sender.sendMessage(Text.color(line));
+        }
+        return true;
+    }
+
+    private boolean handleShop(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player)) {
+            send(sender, "messages.player-only");
+            return false;
+        }
+        Player player = (Player) sender;
+        if (args.length < 2) {
+            send(sender, "messages.invalid-usage");
+            return false;
+        }
+
+        ShopPurchaseResult result = shop.purchase(player, args[1]);
+        ShopPurchaseStatus status = result.getStatus();
+        if (status == ShopPurchaseStatus.DISABLED) {
+            send(sender, "messages.shop-disabled");
+            return false;
+        }
+        if (status == ShopPurchaseStatus.NOT_FOUND) {
+            send(sender, "messages.shop-not-found");
+            return false;
+        }
+        if (status == ShopPurchaseStatus.INVALID_PRICE) {
+            send(sender, "messages.shop-invalid-price");
+            return false;
+        }
+        if (status == ShopPurchaseStatus.NOT_ENOUGH) {
+            send(sender, "messages.not-enough");
+            return false;
+        }
+        if (status == ShopPurchaseStatus.BALANCE_READ_FAILED || status == ShopPurchaseStatus.DEDUCT_FAILED) {
+            send(sender, "messages.operation-failed");
+            return false;
+        }
+
+        String message = plugin.getConfig().getString("messages.shop-buy", "&a购买成功，花费 %amount% %money%")
+                .replace("%amount%", result.getPrice().stripTrailingZeros().toPlainString())
+                .replace("%money%", money.getCurrencyName());
+        player.sendMessage(Text.color(message));
+        return true;
+    }
+
+    private BigDecimal parseAmount(CommandSender sender, String raw) {
+        try {
+            BigDecimal amount = new BigDecimal(raw);
+            if (amount.compareTo(BigDecimal.ZERO) < 0) {
+                send(sender, "messages.invalid-number");
+                return null;
+            }
+            return money.normalize(amount);
+        } catch (Exception ex) {
+            send(sender, "messages.invalid-number");
+            return null;
+        }
+    }
+
+    private void send(CommandSender sender, String key) {
+        sender.sendMessage(Text.color(plugin.getConfig().getString(key, "&cMissing message: " + key)));
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command,
+                                                @NotNull String alias, @NotNull String[] args) {
+        if (args.length == 1) {
+            List<String> subs = Arrays.asList("reload", "give", "take", "reset", "set", "pay", "list", "top", "shop");
+            return subs.stream().filter(s -> s.startsWith(args[0].toLowerCase())).collect(Collectors.toList());
+        }
+        if (args.length == 2 && Arrays.asList("give", "take", "reset", "set", "pay", "list").contains(args[0].toLowerCase())) {
+            if ("list".equalsIgnoreCase(args[0]) && !sender.hasPermission("pnmoney.admin")) {
+                return new ArrayList<String>();
+            }
+            List<String> names = new ArrayList<String>();
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                names.add(p.getName());
+            }
+            return names;
+        }
+        if (args.length == 2 && "shop".equalsIgnoreCase(args[0])) {
+            return shop.getIds().stream().filter(id -> id.startsWith(args[1])).collect(Collectors.toList());
+        }
+        return new ArrayList<String>();
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/data/DatabaseManager.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/data/DatabaseManager.java
@@ -1,0 +1,227 @@
+package uno.mcme.pnmoney.data;
+
+import uno.mcme.pnmoney.PnMoneyPlugin;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class DatabaseManager {
+
+    private final PnMoneyPlugin plugin;
+    private Connection connection;
+    private StorageType storageType;
+
+    public DatabaseManager(PnMoneyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void start() {
+        connectByConfig();
+    }
+
+    public void reload() {
+        close();
+        connectByConfig();
+    }
+
+    private void connectByConfig() {
+        String configured = plugin.getConfig().getString("storage.type", "sqlite").toLowerCase();
+        StorageType targetType = "mysql".equals(configured) ? StorageType.MYSQL : StorageType.SQLITE;
+
+        try {
+            if (targetType == StorageType.MYSQL) {
+                connectMysql();
+                ensureTable();
+                File sqliteFile = new File(plugin.getDataFolder(), "pnmoney.db");
+                if (sqliteFile.exists()) {
+                    migrateFromSqlite(sqliteFile);
+                }
+            } else {
+                connectSqlite();
+                ensureTable();
+            }
+            storageType = targetType;
+            plugin.getLogger().info("PnMoney using storage: " + storageType);
+        } catch (Exception ex) {
+            plugin.getLogger().severe("Database init failed: " + ex.getMessage());
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private void connectSqlite() throws Exception {
+        if (!plugin.getDataFolder().exists()) {
+            plugin.getDataFolder().mkdirs();
+        }
+        Class.forName("org.sqlite.JDBC");
+        File dbFile = new File(plugin.getDataFolder(), "pnmoney.db");
+        connection = DriverManager.getConnection("jdbc:sqlite:" + dbFile.getAbsolutePath());
+    }
+
+    private void connectMysql() throws Exception {
+        Class.forName("org.mariadb.jdbc.Driver");
+        String host = plugin.getConfig().getString("storage.mysql.host", "127.0.0.1");
+        int port = plugin.getConfig().getInt("storage.mysql.port", 3306);
+        String database = plugin.getConfig().getString("storage.mysql.database", "minecraft");
+        String user = plugin.getConfig().getString("storage.mysql.username", "root");
+        String password = plugin.getConfig().getString("storage.mysql.password", "");
+        String url = "jdbc:mariadb://" + host + ":" + port + "/" + database + "?useUnicode=true&characterEncoding=utf8";
+        connection = DriverManager.getConnection(url, user, password);
+    }
+
+    private void ensureTable() throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS pnmoney_balances (" +
+                    "uuid VARCHAR(36) PRIMARY KEY," +
+                    "name VARCHAR(64) NOT NULL," +
+                    "balance DECIMAL(32, 8) NOT NULL" +
+                    ")");
+        }
+    }
+
+    private void migrateFromSqlite(File sqliteFile) {
+        plugin.getLogger().info("Trying to migrate data from SQLite to MySQL...");
+        String sqliteUrl = "jdbc:sqlite:" + sqliteFile.getAbsolutePath();
+        int migrated = 0;
+        try (Connection sqliteConn = DriverManager.getConnection(sqliteUrl);
+             PreparedStatement select = sqliteConn.prepareStatement("SELECT uuid, name, balance FROM pnmoney_balances");
+             ResultSet rs = select.executeQuery()) {
+            while (rs.next()) {
+                String uuid = rs.getString("uuid");
+                String name = rs.getString("name");
+                BigDecimal balance = rs.getBigDecimal("balance");
+                setBalance(UUID.fromString(uuid), name, balance, 8);
+                migrated++;
+            }
+            plugin.getLogger().info("SQLite -> MySQL migration complete, total records: " + migrated);
+        } catch (Exception ex) {
+            plugin.getLogger().warning("Migration skipped/failed: " + ex.getMessage());
+        }
+    }
+
+    public synchronized BigDecimal getOrCreate(UUID uuid, String name, BigDecimal defaultBalance, int scale) {
+        BigDecimal current = getBalance(uuid);
+        if (current != null) {
+            if (name != null) {
+                updateName(uuid, name);
+            }
+            return current.setScale(scale, BigDecimal.ROUND_DOWN);
+        }
+        setBalance(uuid, name, defaultBalance, scale);
+        return defaultBalance;
+    }
+
+    public synchronized BigDecimal getBalance(UUID uuid) {
+        String sql = "SELECT balance FROM pnmoney_balances WHERE uuid = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, uuid.toString());
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getBigDecimal("balance");
+                }
+            }
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Query balance failed: " + ex.getMessage());
+        }
+        return null;
+    }
+
+    private synchronized void updateName(UUID uuid, String name) {
+        String sql = "UPDATE pnmoney_balances SET name = ? WHERE uuid = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, name == null ? "unknown" : name);
+            statement.setString(2, uuid.toString());
+            statement.executeUpdate();
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Update name failed: " + ex.getMessage());
+        }
+    }
+
+    public synchronized boolean setBalance(UUID uuid, String name, BigDecimal balance, int scale) {
+        String sql = "INSERT INTO pnmoney_balances(uuid, name, balance) VALUES(?,?,?) " +
+                "ON DUPLICATE KEY UPDATE name=VALUES(name), balance=VALUES(balance)";
+
+        if (storageType == StorageType.SQLITE) {
+            sql = "INSERT INTO pnmoney_balances(uuid, name, balance) VALUES(?,?,?) " +
+                    "ON CONFLICT(uuid) DO UPDATE SET name=excluded.name, balance=excluded.balance";
+        }
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, uuid.toString());
+            statement.setString(2, name == null ? "unknown" : name);
+            statement.setBigDecimal(3, balance.setScale(scale, BigDecimal.ROUND_DOWN));
+            statement.executeUpdate();
+            return true;
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Set balance failed: " + ex.getMessage());
+            return false;
+        }
+    }
+
+    public synchronized boolean transfer(UUID fromId, String fromName, UUID toId, String toName, BigDecimal amount,
+                                         BigDecimal defaultBalance, boolean allowNegative,
+                                         BigDecimal maxBalance, int scale) {
+        try {
+            connection.setAutoCommit(false);
+
+            BigDecimal fromBal = getOrCreate(fromId, fromName, defaultBalance, scale);
+            BigDecimal toBal = getOrCreate(toId, toName, defaultBalance, scale);
+
+            BigDecimal fromNext = fromBal.subtract(amount);
+            BigDecimal toNext = toBal.add(amount);
+
+            if (!allowNegative && fromNext.compareTo(BigDecimal.ZERO) < 0) {
+                connection.rollback();
+                connection.setAutoCommit(true);
+                return false;
+            }
+            if (toNext.compareTo(maxBalance) > 0) {
+                connection.rollback();
+                connection.setAutoCommit(true);
+                return false;
+            }
+
+            setBalance(fromId, fromName, fromNext, scale);
+            setBalance(toId, toName, toNext, scale);
+            connection.commit();
+            connection.setAutoCommit(true);
+            return true;
+        } catch (Exception ex) {
+            try {
+                connection.rollback();
+                connection.setAutoCommit(true);
+            } catch (SQLException ignored) {
+            }
+            plugin.getLogger().warning("Transfer failed: " + ex.getMessage());
+            return false;
+        }
+    }
+
+    public synchronized List<PlayerBalance> getTop(int limit) {
+        List<PlayerBalance> list = new ArrayList<>();
+        String sql = "SELECT name, balance FROM pnmoney_balances ORDER BY balance DESC LIMIT ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, limit);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    list.add(new PlayerBalance(rs.getString("name"), rs.getBigDecimal("balance")));
+                }
+            }
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Top query failed: " + ex.getMessage());
+        }
+        return list;
+    }
+
+    public void close() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException ignored) {
+            }
+        }
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/data/PlayerBalance.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/data/PlayerBalance.java
@@ -1,0 +1,22 @@
+package uno.mcme.pnmoney.data;
+
+import java.math.BigDecimal;
+
+public class PlayerBalance {
+
+    private final String playerName;
+    private final BigDecimal balance;
+
+    public PlayerBalance(String playerName, BigDecimal balance) {
+        this.playerName = playerName;
+        this.balance = balance;
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public BigDecimal getBalance() {
+        return balance;
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/data/StorageType.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/data/StorageType.java
@@ -1,0 +1,6 @@
+package uno.mcme.pnmoney.data;
+
+public enum StorageType {
+    SQLITE,
+    MYSQL
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/shop/ShopEntry.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/shop/ShopEntry.java
@@ -1,0 +1,29 @@
+package uno.mcme.pnmoney.shop;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class ShopEntry {
+
+    private final String id;
+    private final BigDecimal price;
+    private final List<String> commands;
+
+    public ShopEntry(String id, BigDecimal price, List<String> commands) {
+        this.id = id;
+        this.price = price;
+        this.commands = commands;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public List<String> getCommands() {
+        return commands;
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/shop/ShopManager.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/shop/ShopManager.java
@@ -1,0 +1,134 @@
+package uno.mcme.pnmoney.shop;
+
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import uno.mcme.pnmoney.MoneyManager;
+import uno.mcme.pnmoney.PnMoneyPlugin;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.util.*;
+
+public class ShopManager {
+
+    private final PnMoneyPlugin plugin;
+    private final MoneyManager moneyManager;
+    private final Map<String, ShopEntry> entries = new HashMap<>();
+    private boolean enabled;
+
+    public ShopManager(PnMoneyPlugin plugin, MoneyManager moneyManager) {
+        this.plugin = plugin;
+        this.moneyManager = moneyManager;
+        reload();
+    }
+
+    public void reload() {
+        entries.clear();
+        File file = new File(plugin.getDataFolder(), "shop.yml");
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+
+        enabled = config.getBoolean("use", true);
+        for (String key : config.getKeys(false)) {
+            if ("use".equalsIgnoreCase(key)) {
+                continue;
+            }
+
+            ConfigurationSection section = config.getConfigurationSection(key);
+            if (section == null) {
+                continue;
+            }
+            BigDecimal price = readPrice(section);
+            List<String> commands = new ArrayList<>(section.getStringList("item"));
+            entries.put(key, new ShopEntry(key, price, commands));
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Set<String> getIds() {
+        return entries.keySet();
+    }
+
+    public ShopPurchaseResult purchase(Player player, String id) {
+        if (!enabled) {
+            return ShopPurchaseResult.of(ShopPurchaseStatus.DISABLED);
+        }
+
+        ShopEntry entry = entries.get(id);
+        if (entry == null) {
+            return ShopPurchaseResult.of(ShopPurchaseStatus.NOT_FOUND);
+        }
+
+        BigDecimal price = moneyManager.normalize(entry.getPrice());
+        if (price.compareTo(BigDecimal.ZERO) <= 0) {
+            return ShopPurchaseResult.of(ShopPurchaseStatus.INVALID_PRICE);
+        }
+
+        BigDecimal currentBal = resolveBalanceByPapi(player);
+        if (currentBal == null) {
+            return ShopPurchaseResult.of(ShopPurchaseStatus.BALANCE_READ_FAILED);
+        }
+
+        if (currentBal.compareTo(price) < 0) {
+            return ShopPurchaseResult.of(ShopPurchaseStatus.NOT_ENOUGH);
+        }
+
+        if (!moneyManager.takeBalance(player, price)) {
+            return ShopPurchaseResult.of(ShopPurchaseStatus.DEDUCT_FAILED);
+        }
+
+        for (String cmd : entry.getCommands()) {
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd.replace("%player%", player.getName()));
+        }
+        return ShopPurchaseResult.success(price);
+    }
+
+    private BigDecimal resolveBalanceByPapi(Player player) {
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            String parsed = PlaceholderAPI.setPlaceholders(player, "%pnmoney.bal%");
+            BigDecimal byPapi = tryParseDecimal(parsed);
+            if (byPapi != null) {
+                return moneyManager.normalize(byPapi);
+            }
+            plugin.getLogger().warning("Failed to parse PAPI balance for " + player.getName() + ": " + parsed);
+            return null;
+        }
+        return moneyManager.getBalance(player);
+    }
+
+    private BigDecimal readPrice(ConfigurationSection section) {
+        Object raw = section.get("int");
+        if (raw == null) {
+            return BigDecimal.ZERO;
+        }
+
+        if (raw instanceof Number) {
+            Number number = (Number) raw;
+            return BigDecimal.valueOf(number.doubleValue());
+        }
+
+        BigDecimal parsed = tryParseDecimal(String.valueOf(raw));
+        return parsed == null ? BigDecimal.ZERO : parsed;
+    }
+
+    private BigDecimal tryParseDecimal(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String cleaned = raw.trim().replace(",", "");
+        if (cleaned.isEmpty()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(cleaned);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/shop/ShopPurchaseResult.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/shop/ShopPurchaseResult.java
@@ -1,0 +1,30 @@
+package uno.mcme.pnmoney.shop;
+
+import java.math.BigDecimal;
+
+public class ShopPurchaseResult {
+
+    private final ShopPurchaseStatus status;
+    private final BigDecimal price;
+
+    public ShopPurchaseResult(ShopPurchaseStatus status, BigDecimal price) {
+        this.status = status;
+        this.price = price;
+    }
+
+    public static ShopPurchaseResult of(ShopPurchaseStatus status) {
+        return new ShopPurchaseResult(status, BigDecimal.ZERO);
+    }
+
+    public static ShopPurchaseResult success(BigDecimal price) {
+        return new ShopPurchaseResult(ShopPurchaseStatus.SUCCESS, price);
+    }
+
+    public ShopPurchaseStatus getStatus() {
+        return status;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/shop/ShopPurchaseStatus.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/shop/ShopPurchaseStatus.java
@@ -1,0 +1,11 @@
+package uno.mcme.pnmoney.shop;
+
+public enum ShopPurchaseStatus {
+    SUCCESS,
+    DISABLED,
+    NOT_FOUND,
+    INVALID_PRICE,
+    NOT_ENOUGH,
+    BALANCE_READ_FAILED,
+    DEDUCT_FAILED
+}

--- a/PnMoney/src/main/java/uno/mcme/pnmoney/util/Text.java
+++ b/PnMoney/src/main/java/uno/mcme/pnmoney/util/Text.java
@@ -1,0 +1,12 @@
+package uno.mcme.pnmoney.util;
+
+import org.bukkit.ChatColor;
+
+public final class Text {
+
+    private Text() {}
+
+    public static String color(String text) {
+        return ChatColor.translateAlternateColorCodes('&', text);
+    }
+}

--- a/PnMoney/src/main/resources/config.yml
+++ b/PnMoney/src/main/resources/config.yml
@@ -1,0 +1,40 @@
+currency:
+  name: "金币"
+
+money:
+  allow-negative: false
+  max-decimal: 2
+  max: 999999999.99
+  default: 0.00
+
+storage:
+  # sqlite 或 mysql
+  type: sqlite
+  mysql:
+    host: 127.0.0.1
+    port: 3306
+    database: minecraft
+    username: root
+    password: ""
+
+messages:
+  help: "&6/pnmy reload\n&6/pnmy give [玩家] [数量]\n&6/pnmy take [玩家] [数量]\n&6/pnmy reset [玩家]\n&6/pnmy set [玩家] [数量]\n&6/pnmy pay [玩家] [数量]\n&6/pnmy list [玩家]\n&6/pnmy top\n&6/pnmy shop [商品ID]"
+  no-permission: "&c你没有权限。"
+  reload: "&aPnMoney 已重载。"
+  invalid-usage: "&c参数错误，请查看 /pnmy"
+  invalid-number: "&c请输入正确的数字，且不能为负数。"
+  operation-failed: "&c操作失败。"
+  not-enough: "&c余额不足或超出限制。"
+  reset-success: "&a已重置玩家余额。"
+  player-only: "&c该命令只能由玩家执行。"
+  pay-self: "&c你不能给自己转账。"
+  admin-success: "&a操作成功：%target% 当前余额 %bal% %money%"
+  balance: "&e%target% 余额：&a%bal% %money%"
+  pay-success: "&a你成功支付给 %target% %amount% %money%"
+  receive: "&a你收到来自 %from% 的 %amount% %money%"
+  top-title: "&6==== 货币排行榜 TOP10 ===="
+  top-line: "&e#%index% &f%player% &7- &a%bal% %money%"
+  shop-disabled: "&c商店功能未启用。"
+  shop-not-found: "&c该商品ID不存在。"
+  shop-invalid-price: "&c该商品价格配置错误，请联系管理员。"
+  shop-buy: "&a购买成功，花费 %amount% %money%"

--- a/PnMoney/src/main/resources/plugin.yml
+++ b/PnMoney/src/main/resources/plugin.yml
@@ -1,0 +1,20 @@
+name: PnMoney
+version: 1.0.0
+main: uno.mcme.pnmoney.PnMoneyPlugin
+author: Pn86
+softdepend:
+  - PlaceholderAPI
+commands:
+  pnmy:
+    description: PnMoney 命令
+    usage: /pnmy <reload|give|take|reset|set|pay|list|top|shop>
+permissions:
+  pnmoney.admin:
+    description: PnMoney 管理权限
+    default: op
+  pnmoney.player:
+    description: PnMoney 玩家权限（shop/top/list自己）
+    default: true
+  pnmoney.use:
+    description: PnMoney 兼容旧版普通使用权限
+    default: true

--- a/PnMoney/src/main/resources/shop.yml
+++ b/PnMoney/src/main/resources/shop.yml
@@ -1,0 +1,16 @@
+# 是否启用商店功能
+use: true
+
+# 商品ID（字符串或数字都可以）
+"1":
+  # 商品价格（支持整数或小数；建议写成字符串，避免YAML类型误判）
+  int: "10"
+  # 购买后由控制台执行的命令列表，%player% 会替换为购买玩家名
+  item:
+    - "eco give %player% 100"
+
+"vip_day":
+  int: "88.50"
+  item:
+    - "lp user %player% parent addtemp vip 1d"
+    - "tellraw %player% {\"text\":\"你成功购买了1天VIP！\",\"color\":\"gold\"}"


### PR DESCRIPTION
### Motivation

- Provide a lightweight currency and shop plugin for Bukkit/Spigot servers compatible with `1.8.8` through `1.21.11`.
- Support persistent storage with `SQLite` by default and optional `MySQL` with automatic migration from the default SQLite file.
- Expose a simple programmatic API and PlaceholderAPI placeholders for integration with other plugins.

### Description

- Add core plugin entry `PnMoneyPlugin` that initializes `DatabaseManager`, `MoneyManager`, `ShopManager`, command `pnmy`, and registers PlaceholderAPI expansion (`PnMoneyPlaceholder`).
- Implement money logic in `MoneyManager` and an external API `MoneyService` / `MoneyServiceImpl` for `getBalance`, `setBalance`, `addBalance`, and `takeBalance` operations.
- Implement `DatabaseManager` with SQLite/MySQL connection handling, table creation, SQLite->MySQL migration, safe `setBalance` upserts, transactional `transfer`, and `getTop` queries.
- Add shop subsystem (`ShopManager`, `ShopEntry`, purchase result/status classes) supporting `shop.yml` configured items, PlaceholderAPI-based balance checks, and console command execution on purchase; also add command handling in `PnMoneyCommand` and text utilities in `Text`.
- Add project metadata and resources: `pom.xml` with dependencies, `plugin.yml`, `config.yml`, `shop.yml`, and `README.md` documenting usage, commands, permissions, and API.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b5018efd6c83329bb121abbdac98a5)