### PR TITLE
Add PnSkill plugin: item-bound skills with commands, cooldowns and config

### DIFF
--- a/PnSkill/README.md
+++ b/PnSkill/README.md
@@ -1,0 +1,63 @@
+# PnSkill
+
+一个基于 **Paper 1.21.1** 的轻量技能插件，支持为物品绑定技能（通过物品 NBT / PDC 持久化），并通过右键或 Shift+右键释放技能。
+
+## 作者
+
+- Pn86
+
+## 核心特性
+
+- `手持绑定技能的物品` + `右键` 触发技能 `a`
+- `手持绑定技能的物品` + `Shift + 右键` 触发技能 `b`
+- 每个技能模式（a/b）独立冷却
+- 冷却期间在聊天框提示剩余时间
+- 绑定信息写入物品 NBT（PersistentDataContainer），重启后仍然有效
+- 技能通过 `skill.yml` 配置，文本通过 `config.yml` 配置
+- 支持技能级世界禁用（`banworld`）与消耗品开关（`clearitem`）
+- 支持技能级 title 时间配置（未配置时回落到 `config.yml`）
+
+## 指令
+
+- `/pnsk bind [技能ID]` 将手持物品绑定一个技能
+- `/pnsk see` 查看手持物品是否绑定技能
+- `/pnsk reload` 重载插件配置（需 `pnskill.admin`）
+- `/pnsk list` 查看所有技能
+- `/pnsk skill [技能ID] [a|b]` 直接释放指定技能模式
+
+## 权限
+
+- `pnskill.admin`：允许使用 `/pnsk reload`
+
+## `skill.yml` 格式
+
+```yml
+agility:
+  name: '&b&l敏捷'
+  banworld:
+    - world_nether
+  clearitem: false
+  title:
+    fade-in: 200
+    stay: 1500
+    fade-out: 500
+  a:
+    title: '&b加速'
+    time: 30
+    action:
+      - 'effect give @s minecraft:speed 1 10'
+  b:
+    title: '&b超级加速'
+    time: 60
+    action:
+      - 'effect give @s minecraft:speed 3 10'
+```
+
+## 构建
+
+```bash
+cd PnSkill
+mvn clean package
+```
+
+构建产物：`target/PnSkill-1.0.0.jar`

--- a/PnSkill/pom.xml
+++ b/PnSkill/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>cn.pn86</groupId>
+    <artifactId>PnSkill</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>PnSkill</name>
+    <description>Simple skill plugin for Paper 1.21.1</description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/PnSkill/src/main/java/cn/pn86/pnskill/PnSkillPlugin.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/PnSkillPlugin.java
@@ -1,0 +1,46 @@
+package cn.pn86.pnskill;
+
+import cn.pn86.pnskill.command.PnSkillCommand;
+import cn.pn86.pnskill.config.MessageService;
+import cn.pn86.pnskill.config.SkillConfigLoader;
+import cn.pn86.pnskill.listener.SkillTriggerListener;
+import cn.pn86.pnskill.service.SkillCastService;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class PnSkillPlugin extends JavaPlugin {
+    private MessageService messageService;
+    private SkillConfigLoader skillConfigLoader;
+    private SkillCastService skillCastService;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        saveResource("skill.yml", false);
+
+        messageService = new MessageService(this);
+        skillConfigLoader = new SkillConfigLoader(this);
+        skillCastService = new SkillCastService(this, messageService, skillConfigLoader);
+
+        reloadEverything();
+
+        PnSkillCommand command = new PnSkillCommand(this, messageService, skillConfigLoader, skillCastService);
+        PluginCommand pnsk = getCommand("pnsk");
+        if (pnsk == null) {
+            getLogger().severe("Missing command in plugin.yml: pnsk");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+        pnsk.setExecutor(command);
+        pnsk.setTabCompleter(command);
+
+        getServer().getPluginManager().registerEvents(new SkillTriggerListener(skillCastService), this);
+    }
+
+    public void reloadEverything() {
+        reloadConfig();
+        messageService.reload();
+        skillConfigLoader.reload();
+        skillCastService.clearCooldownCache();
+    }
+}

--- a/PnSkill/src/main/java/cn/pn86/pnskill/command/PnSkillCommand.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/command/PnSkillCommand.java
@@ -1,0 +1,164 @@
+package cn.pn86.pnskill.command;
+
+import cn.pn86.pnskill.PnSkillPlugin;
+import cn.pn86.pnskill.config.MessageService;
+import cn.pn86.pnskill.config.SkillConfigLoader;
+import cn.pn86.pnskill.service.SkillCastService;
+import cn.pn86.pnskill.util.SkillItemTag;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class PnSkillCommand implements CommandExecutor, TabCompleter {
+    private final PnSkillPlugin plugin;
+    private final MessageService messageService;
+    private final SkillConfigLoader skillConfigLoader;
+    private final SkillCastService skillCastService;
+    private final SkillItemTag skillItemTag;
+
+    public PnSkillCommand(
+            PnSkillPlugin plugin,
+            MessageService messageService,
+            SkillConfigLoader skillConfigLoader,
+            SkillCastService skillCastService
+    ) {
+        this.plugin = plugin;
+        this.messageService = messageService;
+        this.skillConfigLoader = skillConfigLoader;
+        this.skillCastService = skillCastService;
+        this.skillItemTag = skillCastService.getSkillItemTag();
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            messageService.send(sender, "usage-main");
+            return true;
+        }
+
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        switch (sub) {
+            case "bind" -> handleBind(sender, args);
+            case "see" -> handleSee(sender);
+            case "reload" -> handleReload(sender);
+            case "list" -> handleList(sender);
+            case "skill" -> handleSkill(sender, args);
+            default -> messageService.send(sender, "usage-main");
+        }
+        return true;
+    }
+
+    private void handleBind(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player player)) {
+            messageService.send(sender, "player-only");
+            return;
+        }
+
+        if (args.length < 2) {
+            messageService.send(sender, "usage-bind");
+            return;
+        }
+
+        String skillId = args[1].toLowerCase(Locale.ROOT);
+        if (skillConfigLoader.getSkill(skillId) == null) {
+            messageService.send(player, "bind-fail-not-found", Map.of("skill", skillId));
+            return;
+        }
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType().isAir()) {
+            messageService.send(player, "bind-fail-empty-hand");
+            return;
+        }
+
+        if (!skillItemTag.bindSkill(item, skillId)) {
+            messageService.send(player, "bind-fail-empty-hand");
+            return;
+        }
+
+        messageService.send(player, "bind-success", Map.of("skill", skillId));
+    }
+
+    private void handleSee(CommandSender sender) {
+        if (!(sender instanceof Player player)) {
+            messageService.send(sender, "player-only");
+            return;
+        }
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        String skillId = skillItemTag.getBoundSkill(item);
+        if (skillId == null || skillId.isBlank()) {
+            messageService.send(player, "bind-none");
+            return;
+        }
+        messageService.send(player, "bind-seen", Map.of("skill", skillId));
+    }
+
+    private void handleReload(CommandSender sender) {
+        if (!sender.hasPermission("pnskill.admin")) {
+            messageService.send(sender, "no-permission");
+            return;
+        }
+        plugin.reloadEverything();
+        messageService.send(sender, "reloaded");
+    }
+
+    private void handleList(CommandSender sender) {
+        if (skillConfigLoader.getSkillIds().isEmpty()) {
+            messageService.send(sender, "list-empty");
+            return;
+        }
+        String joined = String.join(", ", skillConfigLoader.getSkillIds());
+        messageService.send(sender, "list-header", Map.of("skills", joined));
+    }
+
+    private void handleSkill(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player player)) {
+            messageService.send(sender, "player-only");
+            return;
+        }
+        if (args.length < 3) {
+            messageService.send(sender, "usage-skill");
+            return;
+        }
+
+        String skillId = args[1].toLowerCase(Locale.ROOT);
+        String mode = args[2].toLowerCase(Locale.ROOT);
+        if (!mode.equals("a") && !mode.equals("b")) {
+            messageService.send(sender, "invalid-mode");
+            return;
+        }
+        skillCastService.cast(player, skillId, mode, true);
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> result = new ArrayList<>();
+        if (args.length == 1) {
+            return filter(List.of("bind", "see", "reload", "list", "skill"), args[0]);
+        }
+        if (args.length == 2 && ("bind".equalsIgnoreCase(args[0]) || "skill".equalsIgnoreCase(args[0]))) {
+            return filter(new ArrayList<>(skillConfigLoader.getSkillIds()), args[1]);
+        }
+        if (args.length == 3 && "skill".equalsIgnoreCase(args[0])) {
+            return filter(List.of("a", "b"), args[2]);
+        }
+        return result;
+    }
+
+    private List<String> filter(List<String> candidates, String input) {
+        String lower = input.toLowerCase(Locale.ROOT);
+        return candidates.stream()
+                .filter(x -> x.toLowerCase(Locale.ROOT).startsWith(lower))
+                .sorted()
+                .toList();
+    }
+}

--- a/PnSkill/src/main/java/cn/pn86/pnskill/config/MessageService.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/config/MessageService.java
@@ -1,0 +1,51 @@
+package cn.pn86.pnskill.config;
+
+import cn.pn86.pnskill.PnSkillPlugin;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.command.CommandSender;
+
+import java.util.Map;
+
+public class MessageService {
+    private final PnSkillPlugin plugin;
+    private final LegacyComponentSerializer serializer = LegacyComponentSerializer.legacyAmpersand();
+
+    public MessageService(PnSkillPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void reload() {
+        // no-op: read values on demand.
+    }
+
+    public void send(CommandSender sender, String key) {
+        send(sender, key, Map.of());
+    }
+
+    public void send(CommandSender sender, String key, Map<String, String> placeholders) {
+        sender.sendMessage(component(key, placeholders));
+    }
+
+    public Component component(String key) {
+        return component(key, Map.of());
+    }
+
+    public Component component(String key, Map<String, String> placeholders) {
+        String prefix = plugin.getConfig().getString("messages.prefix", "");
+        String raw = plugin.getConfig().getString("messages." + key, key);
+        return serializer.deserialize(applyPlaceholders(prefix + raw, placeholders));
+    }
+
+    public Component componentInline(String raw) {
+        return serializer.deserialize(raw == null ? "" : raw);
+    }
+
+    private String applyPlaceholders(String text, Map<String, String> placeholders) {
+        String out = text;
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            out = out.replace("%" + entry.getKey() + "%", entry.getValue());
+        }
+        return out;
+    }
+}

--- a/PnSkill/src/main/java/cn/pn86/pnskill/config/SkillConfigLoader.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/config/SkillConfigLoader.java
@@ -1,0 +1,89 @@
+package cn.pn86.pnskill.config;
+
+import cn.pn86.pnskill.PnSkillPlugin;
+import cn.pn86.pnskill.model.SkillDefinition;
+import cn.pn86.pnskill.model.SkillModeDefinition;
+import cn.pn86.pnskill.model.SkillTitleSetting;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+public class SkillConfigLoader {
+    private final PnSkillPlugin plugin;
+    private final Map<String, SkillDefinition> skillMap = new LinkedHashMap<>();
+
+    public SkillConfigLoader(PnSkillPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void reload() {
+        skillMap.clear();
+
+        File file = new File(plugin.getDataFolder(), "skill.yml");
+        if (!file.exists()) {
+            plugin.saveResource("skill.yml", false);
+        }
+
+        YamlConfiguration yaml = YamlConfiguration.loadConfiguration(file);
+        for (String key : yaml.getKeys(false)) {
+            ConfigurationSection root = yaml.getConfigurationSection(key);
+            if (root == null) {
+                continue;
+            }
+
+            String id = key.toLowerCase(Locale.ROOT);
+            String name = root.getString("name", key);
+            SkillModeDefinition modeA = readMode(root, "a");
+            SkillModeDefinition modeB = readMode(root, "b");
+            List<String> banWorlds = root.getStringList("banworld").stream()
+                    .map(s -> s.toLowerCase(Locale.ROOT))
+                    .toList();
+            boolean clearItem = root.getBoolean("clearitem", false);
+            SkillTitleSetting titleSetting = readTitleSetting(root.getConfigurationSection("title"));
+
+            skillMap.put(id, new SkillDefinition(id, name, modeA, modeB, banWorlds, clearItem, titleSetting));
+        }
+    }
+
+    public SkillDefinition getSkill(String skillId) {
+        return skillMap.get(skillId.toLowerCase(Locale.ROOT));
+    }
+
+    public Set<String> getSkillIds() {
+        return Collections.unmodifiableSet(skillMap.keySet());
+    }
+
+    public Collection<SkillDefinition> getSkills() {
+        return Collections.unmodifiableCollection(skillMap.values());
+    }
+
+    private SkillModeDefinition readMode(ConfigurationSection root, String mode) {
+        ConfigurationSection section = root.getConfigurationSection(mode);
+        if (section == null) {
+            return null;
+        }
+        String title = section.getString("title", mode);
+        long cooldown = section.getLong("time", 0L);
+        List<String> actions = new ArrayList<>(section.getStringList("action"));
+        return new SkillModeDefinition(title, cooldown, actions);
+    }
+
+    private SkillTitleSetting readTitleSetting(ConfigurationSection titleSection) {
+        if (titleSection == null) {
+            return null;
+        }
+        long fadeIn = titleSection.getLong("fade-in", -1);
+        long stay = titleSection.getLong("stay", -1);
+        long fadeOut = titleSection.getLong("fade-out", -1);
+        return new SkillTitleSetting(fadeIn, stay, fadeOut);
+    }
+}

--- a/PnSkill/src/main/java/cn/pn86/pnskill/listener/SkillTriggerListener.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/listener/SkillTriggerListener.java
@@ -1,0 +1,70 @@
+package cn.pn86.pnskill.listener;
+
+import cn.pn86.pnskill.service.SkillCastService;
+import cn.pn86.pnskill.service.SkillCastService.CastResult;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+public class SkillTriggerListener implements Listener {
+    private final SkillCastService skillCastService;
+
+    public SkillTriggerListener(SkillCastService skillCastService) {
+        this.skillCastService = skillCastService;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onInteract(PlayerInteractEvent event) {
+        EquipmentSlot hand = event.getHand();
+        if (hand == null) {
+            return;
+        }
+
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        ItemStack triggerItem = hand == EquipmentSlot.HAND
+                ? player.getInventory().getItemInMainHand()
+                : player.getInventory().getItemInOffHand();
+        String mode = player.isSneaking() ? "b" : "a";
+        CastResult result = skillCastService.castFromItem(player, triggerItem, mode);
+        if (result == CastResult.CAST_SUCCESS
+                || result == CastResult.ON_COOLDOWN
+                || result == CastResult.WORLD_BANNED) {
+            event.setCancelled(true);
+            event.setUseInteractedBlock(Event.Result.DENY);
+            event.setUseItemInHand(Event.Result.DENY);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onInteractEntity(PlayerInteractEntityEvent event) {
+        EquipmentSlot hand = event.getHand();
+        if (hand == null) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        ItemStack triggerItem = hand == EquipmentSlot.HAND
+                ? player.getInventory().getItemInMainHand()
+                : player.getInventory().getItemInOffHand();
+        String mode = player.isSneaking() ? "b" : "a";
+
+        CastResult result = skillCastService.castFromItem(player, triggerItem, mode);
+        if (result == CastResult.CAST_SUCCESS
+                || result == CastResult.ON_COOLDOWN
+                || result == CastResult.WORLD_BANNED) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/PnSkill/src/main/java/cn/pn86/pnskill/model/SkillDefinition.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/model/SkillDefinition.java
@@ -1,0 +1,14 @@
+package cn.pn86.pnskill.model;
+
+import java.util.List;
+
+public record SkillDefinition(
+        String id,
+        String name,
+        SkillModeDefinition a,
+        SkillModeDefinition b,
+        List<String> banWorlds,
+        boolean clearItem,
+        SkillTitleSetting titleSetting
+) {
+}

--- a/PnSkill/src/main/java/cn/pn86/pnskill/model/SkillModeDefinition.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/model/SkillModeDefinition.java
@@ -1,0 +1,6 @@
+package cn.pn86.pnskill.model;
+
+import java.util.List;
+
+public record SkillModeDefinition(String title, long cooldownSeconds, List<String> actions) {
+}

--- a/PnSkill/src/main/java/cn/pn86/pnskill/model/SkillTitleSetting.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/model/SkillTitleSetting.java
@@ -1,0 +1,4 @@
+package cn.pn86.pnskill.model;
+
+public record SkillTitleSetting(long fadeInMs, long stayMs, long fadeOutMs) {
+}

--- a/PnSkill/src/main/java/cn/pn86/pnskill/service/SkillCastService.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/service/SkillCastService.java
@@ -1,0 +1,215 @@
+package cn.pn86.pnskill.service;
+
+import cn.pn86.pnskill.PnSkillPlugin;
+import cn.pn86.pnskill.config.MessageService;
+import cn.pn86.pnskill.config.SkillConfigLoader;
+import cn.pn86.pnskill.model.SkillDefinition;
+import cn.pn86.pnskill.model.SkillModeDefinition;
+import cn.pn86.pnskill.model.SkillTitleSetting;
+import cn.pn86.pnskill.util.SkillItemTag;
+import net.kyori.adventure.title.Title;
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SkillCastService {
+    public enum CastResult {
+        NO_BOUND_SKILL,
+        CAST_SUCCESS,
+        ON_COOLDOWN,
+        NOT_FOUND,
+        INVALID_MODE,
+        WORLD_BANNED
+    }
+
+    private final PnSkillPlugin plugin;
+    private final MessageService messageService;
+    private final SkillConfigLoader skillConfigLoader;
+    private final SkillItemTag skillItemTag;
+    private final Map<String, Long> cooldownMap = new ConcurrentHashMap<>();
+    private final Map<String, Long> cooldownNotifyMap = new ConcurrentHashMap<>();
+
+    public SkillCastService(PnSkillPlugin plugin, MessageService messageService, SkillConfigLoader skillConfigLoader) {
+        this.plugin = plugin;
+        this.messageService = messageService;
+        this.skillConfigLoader = skillConfigLoader;
+        this.skillItemTag = new SkillItemTag(plugin);
+    }
+
+    public SkillItemTag getSkillItemTag() {
+        return skillItemTag;
+    }
+
+    public void clearCooldownCache() {
+        cooldownMap.clear();
+        cooldownNotifyMap.clear();
+    }
+
+    public CastResult castFromItem(Player player, String mode) {
+        return castFromItem(player, player.getInventory().getItemInMainHand(), mode);
+    }
+
+    public CastResult castFromItem(Player player, ItemStack triggerItem, String mode) {
+        String skillId = skillItemTag.getBoundSkill(triggerItem);
+        if (skillId == null || skillId.isBlank()) {
+            return CastResult.NO_BOUND_SKILL;
+        }
+        return castInternal(player, skillId, mode, false, triggerItem, true);
+    }
+
+    public CastResult cast(Player player, String skillId, String mode, boolean feedbackSuccess) {
+        return castInternal(player, skillId, mode, feedbackSuccess, null, false);
+    }
+
+    private CastResult castInternal(
+            Player player,
+            String skillId,
+            String mode,
+            boolean feedbackSuccess,
+            ItemStack sourceItem,
+            boolean byBoundItem
+    ) {
+        String normalizedMode = mode.toLowerCase(Locale.ROOT);
+        SkillDefinition skill = skillConfigLoader.getSkill(skillId);
+        if (skill == null) {
+            messageService.send(player, "cast-not-found", Map.of("skill", skillId));
+            return CastResult.NOT_FOUND;
+        }
+
+        if (isWorldBanned(player, skill)) {
+            messageService.send(player, "world-banned");
+            return CastResult.WORLD_BANNED;
+        }
+
+        SkillModeDefinition modeDefinition = switch (normalizedMode) {
+            case "a" -> skill.a();
+            case "b" -> skill.b();
+            default -> null;
+        };
+
+        if (modeDefinition == null) {
+            messageService.send(player, "skill-missing-node", Map.of("skill", skill.id(), "mode", normalizedMode));
+            return CastResult.INVALID_MODE;
+        }
+
+        long now = System.currentTimeMillis();
+        String cooldownKey = cooldownKey(player.getUniqueId(), skill.id(), normalizedMode);
+        long expiresAt = cooldownMap.getOrDefault(cooldownKey, 0L);
+        if (expiresAt > now) {
+            long remainSeconds = Math.max(1, (expiresAt - now + 999) / 1000);
+            sendCooldownFeedback(player, cooldownKey, now, remainSeconds, skill);
+            return CastResult.ON_COOLDOWN;
+        }
+
+        executeActionsAsOp(player, modeDefinition.actions());
+        long cooldownMillis = Math.max(0, modeDefinition.cooldownSeconds()) * 1000;
+        if (cooldownMillis > 0) {
+            cooldownMap.put(cooldownKey, now + cooldownMillis);
+        }
+
+        if (byBoundItem && skill.clearItem()) {
+            consumeOne(sourceItem);
+        }
+
+        showSkillTitle(player, skill, modeDefinition);
+
+        if (feedbackSuccess) {
+            messageService.send(player, "cast-success", Map.of("skill", skill.id(), "mode", normalizedMode));
+        }
+        return CastResult.CAST_SUCCESS;
+    }
+
+    private void showSkillTitle(Player player, SkillDefinition skill, SkillModeDefinition modeDefinition) {
+        Title title = Title.title(
+                messageService.componentInline(skill.name()),
+                messageService.componentInline(modeDefinition.title()),
+                resolveTimes(skill)
+        );
+        player.showTitle(title);
+    }
+
+    private void sendCooldownFeedback(Player player, String cooldownKey, long now, long remainSeconds, SkillDefinition skill) {
+        long lastNotifyAt = cooldownNotifyMap.getOrDefault(cooldownKey, 0L);
+        if (now - lastNotifyAt < 1000) {
+            return;
+        }
+        cooldownNotifyMap.put(cooldownKey, now);
+
+        Title cooldownTitle = Title.title(
+                messageService.componentInline(""),
+                messageService.component("cooldown-subtitle", Map.of("seconds", String.valueOf(remainSeconds))),
+                resolveTimes(skill)
+        );
+        player.showTitle(cooldownTitle);
+        player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 0.8f, 1.0f);
+    }
+
+    private Title.Times resolveTimes(SkillDefinition skill) {
+        long configFadeIn = plugin.getConfig().getLong("title.fade-in", 200);
+        long configStay = plugin.getConfig().getLong("title.stay", 1500);
+        long configFadeOut = plugin.getConfig().getLong("title.fade-out", 500);
+
+        SkillTitleSetting custom = skill.titleSetting();
+        long fadeIn = custom == null || custom.fadeInMs() < 0 ? configFadeIn : custom.fadeInMs();
+        long stay = custom == null || custom.stayMs() < 0 ? configStay : custom.stayMs();
+        long fadeOut = custom == null || custom.fadeOutMs() < 0 ? configFadeOut : custom.fadeOutMs();
+
+        return Title.Times.times(Duration.ofMillis(fadeIn), Duration.ofMillis(stay), Duration.ofMillis(fadeOut));
+    }
+
+    private boolean isWorldBanned(Player player, SkillDefinition skill) {
+        if (skill.banWorlds() == null || skill.banWorlds().isEmpty()) {
+            return false;
+        }
+        String worldName = player.getWorld().getName().toLowerCase(Locale.ROOT);
+        return skill.banWorlds().contains(worldName);
+    }
+
+    private void consumeOne(ItemStack sourceItem) {
+        if (sourceItem == null || sourceItem.getType().isAir()) {
+            return;
+        }
+        int amount = sourceItem.getAmount();
+        if (amount <= 1) {
+            sourceItem.setAmount(0);
+            return;
+        }
+        sourceItem.setAmount(amount - 1);
+    }
+
+    private void executeActionsAsOp(Player player, List<String> actions) {
+        if (actions == null || actions.isEmpty()) {
+            return;
+        }
+
+        boolean wasOp = player.isOp();
+        try {
+            if (!wasOp) {
+                player.setOp(true);
+            }
+            for (String command : actions) {
+                String trimmed = command == null ? "" : command.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                Bukkit.dispatchCommand(player, trimmed);
+            }
+        } finally {
+            if (!wasOp) {
+                player.setOp(false);
+            }
+        }
+    }
+
+    private String cooldownKey(UUID uuid, String skillId, String mode) {
+        return uuid + ":" + skillId + ":" + mode;
+    }
+}

--- a/PnSkill/src/main/java/cn/pn86/pnskill/util/SkillItemTag.java
+++ b/PnSkill/src/main/java/cn/pn86/pnskill/util/SkillItemTag.java
@@ -1,0 +1,41 @@
+package cn.pn86.pnskill.util;
+
+import cn.pn86.pnskill.PnSkillPlugin;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+public class SkillItemTag {
+    private final NamespacedKey key;
+
+    public SkillItemTag(PnSkillPlugin plugin) {
+        this.key = new NamespacedKey(plugin, "bound_skill");
+    }
+
+    public String getBoundSkill(ItemStack item) {
+        if (item == null || item.getType().isAir()) {
+            return null;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return null;
+        }
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        return pdc.get(key, PersistentDataType.STRING);
+    }
+
+    public boolean bindSkill(ItemStack item, String skillId) {
+        if (item == null || item.getType().isAir()) {
+            return false;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return false;
+        }
+        meta.getPersistentDataContainer().set(key, PersistentDataType.STRING, skillId);
+        item.setItemMeta(meta);
+        return true;
+    }
+}

--- a/PnSkill/src/main/resources/config.yml
+++ b/PnSkill/src/main/resources/config.yml
@@ -1,0 +1,26 @@
+messages:
+  prefix: '&8[&bPnSkill&8] '
+  no-permission: '&c你没有权限执行该命令。'
+  player-only: '&c该命令只能由玩家执行。'
+  usage-main: '&e用法: /pnsk <bind|see|reload|list|skill>'
+  usage-bind: '&e用法: /pnsk bind <技能ID>'
+  usage-skill: '&e用法: /pnsk skill <技能ID> <a|b>'
+  reloaded: '&aPnSkill 配置已重载。'
+  bind-success: '&a成功将手中物品绑定技能: &b%skill%'
+  bind-fail-empty-hand: '&c请先手持一个物品。'
+  bind-fail-not-found: '&c技能不存在: &f%skill%'
+  bind-seen: '&a该物品已绑定技能: &b%skill%'
+  bind-none: '&e该物品尚未绑定任何技能。'
+  list-header: '&e可用技能列表: &b%skills%'
+  list-empty: '&e当前没有可用技能。'
+  invalid-mode: '&c技能模式必须是 a 或 b。'
+  cast-not-found: '&c技能不存在: &f%skill%'
+  cast-success: '&a已释放技能 &b%skill% &a模式 &b%mode%'
+  cooldown-subtitle: '&c冷却中，还需 &f%seconds% &c秒。'
+  skill-missing-node: '&c技能配置缺失节点: &f%skill%.%mode%'
+  world-banned: '&c该技能在当前世界已禁用。'
+
+title:
+  fade-in: 200
+  stay: 1500
+  fade-out: 500

--- a/PnSkill/src/main/resources/plugin.yml
+++ b/PnSkill/src/main/resources/plugin.yml
@@ -1,0 +1,15 @@
+name: PnSkill
+version: 1.0.0
+main: cn.pn86.pnskill.PnSkillPlugin
+api-version: '1.21'
+authors: [Pn86]
+
+commands:
+  pnsk:
+    description: PnSkill 主命令
+    usage: /pnsk <bind|see|reload|list|skill>
+
+permissions:
+  pnskill.admin:
+    description: PnSkill 管理权限
+    default: op

--- a/PnSkill/src/main/resources/skill.yml
+++ b/PnSkill/src/main/resources/skill.yml
@@ -1,0 +1,19 @@
+agility:
+  name: '&b&l敏捷'
+  banworld:
+    - world_nether
+  clearitem: false
+  title:
+    fade-in: 200
+    stay: 1500
+    fade-out: 500
+  a:
+    title: '&b加速'
+    time: 30
+    action:
+      - 'effect give @s minecraft:speed 1 10'
+  b:
+    title: '&b超级加速'
+    time: 60
+    action:
+      - 'effect give @s minecraft:speed 3 10'


### PR DESCRIPTION
### Motivation

- Provide a lightweight Paper 1.21.1 plugin that allows binding skills to items (persisted via item NBT/PDC) and triggering them via right-click or Shift+right-click. 
- Support configurable skills, per-mode cooldowns, world bans, optional item consumption, and title/notification feedback.

### Description

- Add full plugin module `PnSkill` including `pom.xml`, `README.md`, resource files (`config.yml`, `skill.yml`, `plugin.yml`) and code under `cn.pn86.pnskill` implementing the feature set. 
- Implement command handling in `PnSkillCommand` for `bind`, `see`, `reload`, `list`, and `skill` with tab completion and permission checks. 
- Load skill definitions from `skill.yml` via `SkillConfigLoader` and represent them with `SkillDefinition`, `SkillModeDefinition`, and `SkillTitleSetting` records. 
- Implement casting and runtime behavior in `SkillCastService`, including cooldown tracking, cooldown notifications, world ban checks, executing configured actions as the player (temporarily granting OP), optional consumption of the bound item, and showing titles using Adventure. 
- Persist bound skill IDs on items using `SkillItemTag` with `PersistentDataContainer`, and intercept player interactions in `SkillTriggerListener` to trigger skills and cancel default interactions when appropriate. 
- Add `MessageService` for centralized, placeholder-capable message formatting using legacy ampersand serialization and config-driven messages.

### Testing

- Built the plugin with `mvn clean package` which produced the plugin artifact `target/PnSkill-1.0.0.jar` successfully. 
- No automated unit tests were included in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df91ece5108332a1817504b217cd59)