### PR TITLE
新增 PnBookNews 公告书插件

### DIFF
--- a/PnBookNews/README.md
+++ b/PnBookNews/README.md
@@ -1,0 +1,150 @@
+# PnBookNews 使用说明
+
+PnBookNews 是一个适用于 Paper 1.21.1+ 的简易公告书插件。玩家进入服务器时，插件会自动在玩家界面打开一本写好的公告书；如果服务器安装并启用了 AuthMe，且配置开启兼容，则会在玩家完成 AuthMe 登录后再打开公告书。
+
+## 基本信息
+
+- 插件名：`PnBookNews`
+- 作者：`Pn86`
+- 服务器核心：Paper `1.21.1+`
+- 可选兼容：`AuthMe`、`PlaceholderAPI`
+- 管理命令：`/pnbn reload`
+- 管理权限：`pnbooknews.admin`
+
+## 安装方法
+
+1. 将编译出的 `PnBookNews-1.0.0.jar` 放入服务器 `plugins` 文件夹。
+2. 重启服务器。
+3. 打开 `plugins/PnBookNews/config.yml` 修改公告内容。
+4. 修改完成后执行 `/pnbn reload` 重载配置。
+
+## config.yml 配置说明
+
+```yaml
+settings:
+  enabled: true
+  show-on-every-join: true
+  open-delay-ticks: 20
+  authme-compat: true
+  placeholderapi: true
+
+book:
+  title: '&6服务器公告'
+  author: '&bPn86'
+  pages:
+    - |-
+      &6&l欢迎来到服务器
+      &0你好，&a%player_name%&0！
+
+      &0请阅读本公告。
+      &e祝你游戏愉快！
+```
+
+### settings 设置
+
+| 配置项 | 说明 |
+| --- | --- |
+| `enabled` | 插件总开关，`true` 为启用，`false` 为关闭打开公告书功能。 |
+| `show-on-every-join` | 是否每次进入服务器都打开公告书。设置为 `false` 后玩家进入或 AuthMe 登录后都不会自动弹出。 |
+| `open-delay-ticks` | 延迟打开公告书的时间，单位是 tick，`20` tick = 1 秒。 |
+| `authme-compat` | 是否启用 AuthMe 兼容。服务器有 AuthMe 时，玩家登录 AuthMe 后打开公告书。 |
+| `placeholderapi` | 是否启用 PlaceholderAPI 变量解析。需要服务器安装 PlaceholderAPI。 |
+
+## 如何配置 book 内容
+
+`book.pages` 是公告书页面列表。每个 `- |-` 代表一页书页，下面缩进的文字就是这一页的内容。
+
+### 单页公告示例
+
+```yaml
+book:
+  title: '&6服务器公告'
+  author: '&bPn86'
+  pages:
+    - |-
+      &6&l欢迎来到服务器
+      &0玩家：&a%player_name%
+      &0当前世界：&e%player_world%
+
+      &c请遵守服务器规则！
+```
+
+### 多页公告示例
+
+```yaml
+book:
+  title: '&6服务器公告'
+  author: '&bPn86'
+  pages:
+    - |-
+      &6&l第一页：欢迎
+      &0欢迎 &a%player_name% &0加入服务器！
+    - |-
+      &b&l第二页：常用命令
+      &0/spawn &7返回出生点
+      &0/tpa 玩家名 &7请求传送
+    - |-
+      &c&l第三页：规则
+      &01. 禁止作弊
+      &02. 禁止恶意破坏
+```
+
+## 颜色字符
+
+插件支持使用 `&` 颜色字符，例如：
+
+- `&0` 黑色
+- `&a` 绿色
+- `&b` 青色
+- `&c` 红色
+- `&e` 黄色
+- `&l` 加粗
+- `&n` 下划线
+- `&r` 重置格式
+
+示例：
+
+```yaml
+- |-
+  &6&l服务器公告
+  &a这是一行绿色文字
+  &c这是一行红色文字
+```
+
+## PlaceholderAPI 变量
+
+如果服务器安装了 PlaceholderAPI，并且 `settings.placeholderapi: true`，公告书标题、作者和每一页内容都可以使用 PAPI 变量。
+
+示例：
+
+```yaml
+- |-
+  &0玩家名：&a%player_name%
+  &0所在世界：&e%player_world%
+  &0在线人数：&b%server_online%
+```
+
+## AuthMe 兼容说明
+
+- 如果服务器没有安装 AuthMe：玩家进入服务器后按 `open-delay-ticks` 延迟打开公告书。
+- 如果服务器安装了 AuthMe，并且 `settings.authme-compat: true`：玩家进入服务器时不会立刻打开公告书，而是在 AuthMe 登录成功后打开公告书。
+- 如果想无视 AuthMe，进服就弹公告书，请设置：
+
+```yaml
+settings:
+  authme-compat: false
+```
+
+## 重载配置
+
+修改 `config.yml` 后执行：
+
+```text
+/pnbn reload
+```
+
+需要权限：
+
+```text
+pnbooknews.admin
+```

--- a/PnBookNews/pom.xml
+++ b/PnBookNews/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>cn.pn86</groupId>
+    <artifactId>PnBookNews</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>PnBookNews</name>
+    <description>Join announcement book plugin for Paper 1.21.1</description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.6</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/PnBookNews/src/main/java/cn/pn86/pnbooknews/PnBookNewsPlugin.java
+++ b/PnBookNews/src/main/java/cn/pn86/pnbooknews/PnBookNewsPlugin.java
@@ -1,0 +1,174 @@
+package cn.pn86.pnbooknews;
+
+import cn.pn86.pnbooknews.command.PnBookNewsCommand;
+import cn.pn86.pnbooknews.listener.AuthMeBookListener;
+import cn.pn86.pnbooknews.listener.JoinBookListener;
+import cn.pn86.pnbooknews.util.TextUtil;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PnBookNewsPlugin extends JavaPlugin {
+
+    private boolean authMeHooked;
+    private boolean placeholderApiHooked;
+    private AuthMeBookListener authMeBookListener;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        registerCommand();
+        getServer().getPluginManager().registerEvents(new JoinBookListener(this), this);
+        reloadBookNews();
+        getLogger().info("PnBookNews 已启用。");
+    }
+
+    @Override
+    public void onDisable() {
+        unregisterAuthMeListener();
+    }
+
+    public boolean reloadBookNews() {
+        try {
+            reloadConfig();
+            unregisterAuthMeListener();
+            this.placeholderApiHooked = isPlaceholderApiUsable();
+            this.authMeHooked = false;
+
+            if (isAuthMeCompatEnabled()) {
+                this.authMeBookListener = AuthMeBookListener.register(this);
+                this.authMeHooked = this.authMeBookListener != null;
+            }
+
+            logHookStatus();
+            return true;
+        } catch (Exception ex) {
+            getLogger().severe("重载配置失败: " + ex.getMessage());
+            return false;
+        }
+    }
+
+    public void openNewsBookLater(Player player) {
+        if (!getConfig().getBoolean("settings.enabled", true)) {
+            return;
+        }
+        long delay = Math.max(0L, getConfig().getLong("settings.open-delay-ticks", 20L));
+        Bukkit.getScheduler().runTaskLater(this, () -> {
+            if (player.isOnline()) {
+                openNewsBook(player);
+            }
+        }, delay);
+    }
+
+    public void openNewsBook(Player player) {
+        ItemStack book = createBook(player);
+        player.openBook(book);
+    }
+
+    private ItemStack createBook(Player player) {
+        FileConfiguration config = getConfig();
+        ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
+        BookMeta meta = (BookMeta) book.getItemMeta();
+        if (meta == null) {
+            return book;
+        }
+
+        meta.setTitle(formatForPlayer(player, config.getString("book.title", "PnBookNews")));
+        meta.setAuthor(formatForPlayer(player, config.getString("book.author", "Pn86")));
+
+        List<String> pages = config.getStringList("book.pages");
+        if (pages.isEmpty()) {
+            pages = List.of("&c公告书没有配置任何页面。\n&7请编辑 config.yml 的 book.pages。");
+        }
+        for (String page : pages) {
+            meta.addPage(formatForPlayer(player, page));
+        }
+
+        book.setItemMeta(meta);
+        return book;
+    }
+
+    public String msg(String key) {
+        return TextUtil.color(getConfig().getString("language." + key, ""));
+    }
+
+    public String getPrefix() {
+        return msg("prefix");
+    }
+
+    public String formatForPlayer(Player player, String text) {
+        String result = text == null ? "" : text;
+        if (placeholderApiHooked) {
+            result = PlaceholderAPI.setPlaceholders(player, result);
+        }
+        return TextUtil.color(result);
+    }
+
+    public boolean shouldShowOnJoin() {
+        return getConfig().getBoolean("settings.show-on-every-join", true);
+    }
+
+    public boolean isAuthMeCompatEnabled() {
+        return getConfig().getBoolean("settings.authme-compat", true);
+    }
+
+    public boolean isAuthMeHooked() {
+        return authMeHooked;
+    }
+
+    private void unregisterAuthMeListener() {
+        if (authMeBookListener != null) {
+            HandlerList.unregisterAll(authMeBookListener);
+            authMeBookListener = null;
+        }
+    }
+
+    private boolean isPlaceholderApiUsable() {
+        return getConfig().getBoolean("settings.placeholderapi", true)
+            && getServer().getPluginManager().isPluginEnabled("PlaceholderAPI");
+    }
+
+    private void registerCommand() {
+        PluginCommand command = getCommand("pnbn");
+        if (command == null) {
+            throw new IllegalStateException("pnbn command not found in plugin.yml");
+        }
+        PnBookNewsCommand executor = new PnBookNewsCommand(this);
+        command.setExecutor(executor);
+        command.setTabCompleter((sender, cmd, label, args) -> {
+            if (args.length == 1 && sender.hasPermission("pnbooknews.admin")) {
+                List<String> completions = new ArrayList<>();
+                if ("reload".startsWith(args[0].toLowerCase())) {
+                    completions.add("reload");
+                }
+                return completions;
+            }
+            return Collections.emptyList();
+        });
+    }
+
+    private void logHookStatus() {
+        if (placeholderApiHooked) {
+            getLogger().info(TextUtil.color(msg("papi-hooked")));
+        } else {
+            getLogger().info(TextUtil.color(msg("papi-not-found")));
+        }
+
+        if (authMeHooked) {
+            getLogger().info(TextUtil.color(msg("authme-hooked")));
+        } else {
+            getLogger().info(TextUtil.color(msg("authme-not-found")));
+        }
+    }
+}

--- a/PnBookNews/src/main/java/cn/pn86/pnbooknews/command/PnBookNewsCommand.java
+++ b/PnBookNews/src/main/java/cn/pn86/pnbooknews/command/PnBookNewsCommand.java
@@ -1,0 +1,31 @@
+package cn.pn86.pnbooknews.command;
+
+import cn.pn86.pnbooknews.PnBookNewsPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class PnBookNewsCommand implements CommandExecutor {
+
+    private final PnBookNewsPlugin plugin;
+
+    public PnBookNewsCommand(PnBookNewsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("pnbooknews.admin")) {
+            sender.sendMessage(plugin.getPrefix() + plugin.msg("no-permission"));
+            return true;
+        }
+
+        if (args.length == 1 && args[0].equalsIgnoreCase("reload")) {
+            boolean ok = plugin.reloadBookNews();
+            sender.sendMessage(plugin.getPrefix() + (ok ? plugin.msg("reloaded") : plugin.msg("reload-failed")));
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/PnBookNews/src/main/java/cn/pn86/pnbooknews/listener/AuthMeBookListener.java
+++ b/PnBookNews/src/main/java/cn/pn86/pnbooknews/listener/AuthMeBookListener.java
@@ -1,0 +1,73 @@
+package cn.pn86.pnbooknews.listener;
+
+import cn.pn86.pnbooknews.PnBookNewsPlugin;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventException;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.EventExecutor;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class AuthMeBookListener implements Listener {
+
+    private static final String AUTHME_LOGIN_EVENT_CLASS = "fr.xephi.authme.events.LoginEvent";
+
+    private final PnBookNewsPlugin plugin;
+    private final Method getPlayerMethod;
+
+    private AuthMeBookListener(PnBookNewsPlugin plugin, Method getPlayerMethod) {
+        this.plugin = plugin;
+        this.getPlayerMethod = getPlayerMethod;
+    }
+
+    public static AuthMeBookListener register(PnBookNewsPlugin plugin) {
+        if (!plugin.getServer().getPluginManager().isPluginEnabled("AuthMe")) {
+            return null;
+        }
+
+        try {
+            Class<?> eventClass = Class.forName(AUTHME_LOGIN_EVENT_CLASS);
+            if (!Event.class.isAssignableFrom(eventClass)) {
+                plugin.getLogger().warning("AuthMe 登录事件不是 Bukkit Event，已跳过兼容挂钩。");
+                return null;
+            }
+
+            Method getPlayerMethod = eventClass.getMethod("getPlayer");
+            if (!Player.class.isAssignableFrom(getPlayerMethod.getReturnType())) {
+                plugin.getLogger().warning("AuthMe LoginEvent#getPlayer 返回值不是 Player，已跳过兼容挂钩。");
+                return null;
+            }
+
+            AuthMeBookListener listener = new AuthMeBookListener(plugin, getPlayerMethod);
+            EventExecutor executor = listener::execute;
+            plugin.getServer().getPluginManager().registerEvent(
+                eventClass.asSubclass(Event.class),
+                listener,
+                EventPriority.MONITOR,
+                executor,
+                plugin,
+                true
+            );
+            return listener;
+        } catch (ClassNotFoundException ex) {
+            plugin.getLogger().warning("未找到 AuthMe LoginEvent，已跳过兼容挂钩。");
+        } catch (NoSuchMethodException ex) {
+            plugin.getLogger().warning("未找到 AuthMe LoginEvent#getPlayer，已跳过兼容挂钩。");
+        }
+        return null;
+    }
+
+    private void execute(Listener listener, Event event) throws EventException {
+        try {
+            Player player = (Player) getPlayerMethod.invoke(event);
+            if (plugin.shouldShowOnJoin()) {
+                plugin.openNewsBookLater(player);
+            }
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            throw new EventException(ex);
+        }
+    }
+}

--- a/PnBookNews/src/main/java/cn/pn86/pnbooknews/listener/JoinBookListener.java
+++ b/PnBookNews/src/main/java/cn/pn86/pnbooknews/listener/JoinBookListener.java
@@ -1,0 +1,26 @@
+package cn.pn86.pnbooknews.listener;
+
+import cn.pn86.pnbooknews.PnBookNewsPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class JoinBookListener implements Listener {
+
+    private final PnBookNewsPlugin plugin;
+
+    public JoinBookListener(PnBookNewsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        if (!plugin.shouldShowOnJoin()) {
+            return;
+        }
+        if (plugin.isAuthMeCompatEnabled() && plugin.isAuthMeHooked()) {
+            return;
+        }
+        plugin.openNewsBookLater(event.getPlayer());
+    }
+}

--- a/PnBookNews/src/main/java/cn/pn86/pnbooknews/util/TextUtil.java
+++ b/PnBookNews/src/main/java/cn/pn86/pnbooknews/util/TextUtil.java
@@ -1,0 +1,16 @@
+package cn.pn86.pnbooknews.util;
+
+import org.bukkit.ChatColor;
+
+public final class TextUtil {
+
+    private TextUtil() {
+    }
+
+    public static String color(String text) {
+        if (text == null) {
+            return "";
+        }
+        return ChatColor.translateAlternateColorCodes('&', text);
+    }
+}

--- a/PnBookNews/src/main/resources/config.yml
+++ b/PnBookNews/src/main/resources/config.yml
@@ -1,0 +1,46 @@
+# PnBookNews 配置文件
+settings:
+  # 是否启用插件总开关。
+  enabled: true
+  # 玩家每次进入服务器时是否弹出公告书。
+  show-on-every-join: true
+  # 玩家进服后延迟多少 tick 打开书。20 tick = 1 秒。
+  open-delay-ticks: 20
+  # 是否启用 AuthMe 兼容。启用且服务器安装 AuthMe 时，会在玩家登录 AuthMe 后打开书。
+  authme-compat: true
+  # 是否启用 PlaceholderAPI 变量解析。需要服务器安装 PlaceholderAPI。
+  placeholderapi: true
+
+book:
+  title: '&6服务器公告'
+  author: '&bPn86'
+  # 每个列表项是一页书页。支持 & 颜色字符和 PlaceholderAPI 变量。
+  pages:
+    - |-
+      &6&l欢迎来到服务器
+      &0你好，&a%player_name%&0！
+
+      &0请阅读本公告。
+      &e祝你游戏愉快！
+    - |-
+      &b&l常用命令
+      &0/spawn &7返回出生点
+      &0/tpa 玩家名 &7请求传送
+      &0/pwarp &7打开地标菜单
+    - |-
+      &c&l服务器规则
+      &01. 禁止作弊
+      &02. 禁止恶意破坏
+      &03. 友好交流
+
+language:
+  prefix: '&7[&6PnBookNews&7] '
+  no-permission: '&c你没有权限执行这个命令。'
+  only-player: '&c该命令只能由玩家执行。'
+  reloaded: '&a插件已重载。'
+  reload-failed: '&c插件重载失败，请检查控制台。'
+  disabled: '&c插件当前已关闭。'
+  authme-hooked: '&a已检测到 AuthMe，公告书将在玩家登录后打开。'
+  authme-not-found: '&e未检测到 AuthMe，公告书将在玩家进入服务器后打开。'
+  papi-hooked: '&a已检测到 PlaceholderAPI，已启用变量解析。'
+  papi-not-found: '&e未检测到 PlaceholderAPI，将跳过 PAPI 变量解析。'

--- a/PnBookNews/src/main/resources/plugin.yml
+++ b/PnBookNews/src/main/resources/plugin.yml
@@ -1,0 +1,14 @@
+name: PnBookNews
+main: cn.pn86.pnbooknews.PnBookNewsPlugin
+version: 1.0.0
+api-version: '1.21'
+authors: [Pn86]
+softdepend: [AuthMe, PlaceholderAPI]
+commands:
+  pnbn:
+    description: PnBookNews main command
+    usage: /pnbn reload
+    permission: pnbooknews.admin
+permissions:
+  pnbooknews.admin:
+    default: op


### PR DESCRIPTION
### Motivation

- 提供一个在玩家进入服务器时显示公告书的轻量级 Paper 1.21.1+ 插件以便推送规则/欢迎信息。 
- 自动兼容 `AuthMe`，在玩家完成 AuthMe 登录后再展示公告以避免未登录时弹窗。 
- 支持 `&` 颜色字符和 `PlaceholderAPI` 变量以便在书页中显示玩家/服务器占位信息并保持配置简单。 

### Description

- 新增模块文件和资源，包括 `PnBookNews/pom.xml`、`src/main/resources/plugin.yml`、`src/main/resources/config.yml`、`README.md` 以及插件代码在 `src/main/java/cn/pn86/pnbooknews` 下的若干类。 
- 实现加入时打开书的逻辑，使用 `JoinBookListener` 处理 `PlayerJoinEvent` 并通过 `openNewsBookLater` 在可配置的 `open-delay-ticks` 后调用 `player.openBook` 打开书。 
- 通过反射动态注册 `AuthMe` 登录事件监听器 `AuthMeBookListener.register(...)` 并在重载或停用时通过 `HandlerList.unregisterAll(...)` 解除注册以避免重复监听。 
- 在 `PnBookNewsPlugin.formatForPlayer` 中按配置使用 `PlaceholderAPI.setPlaceholders(...)` 替换变量并使用 `TextUtil.color(...)` 处理 `&` 颜色字符，并提供 `/pnbn reload` 命令由 `PnBookNewsCommand` 实现以重载配置和重新检测插件挂钩状态。 

### Testing

- 成功运行静态检查 `git diff --cached --check` 并已提交变更到版本库。 
- 尝试构建 `mvn -q -f PnBookNews/pom.xml package` 时失败，原因是构建环境在解析 `maven-resources-plugin:3.3.1` 时访问 Maven Central 返回 `403 Forbidden`，因此无法完成本地打包。 
- 已验证 `git status --short`/`git commit` 流程成功并创建了提交包含新增 9 个文件。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a080d82de6c8332ac88abac5d325fb6)